### PR TITLE
Add istio 1.12

### DIFF
--- a/istio-install/1.12/eastwest-gateway-lb.yaml
+++ b/istio-install/1.12/eastwest-gateway-lb.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-eastwestgateway
+  # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-eastwest
+spec:
+  type: LoadBalancer
+  selector:
+    istio: eastwestgateway
+    version: $REVISION
+  ports:
+  # Health check port. For AWS ELBs, this port must be listed first.
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+  # Port for multicluster mTLS passthrough; required for Gloo Mesh east/west routing
+  - port: 15443
+    targetPort: 15443
+    # Gloo Mesh looks for this default name 'tls' on an ingress gateway
+    name: tls

--- a/istio-install/1.12/eastwest-gateway.yaml
+++ b/istio-install/1.12/eastwest-gateway.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-eastwestgateway
+  # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-eastwest
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: eastwest-gateway-$REVISION
+  # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-eastwest
+spec:
+  # No control plane components are installed
+  profile: empty
+  # Solo.io Istio distribution repository; required for Gloo Mesh Istio. You get the repo key from your Solo Account Representative.
+  hub: $REPO
+  # The Solo.io Gloo Mesh Istio version
+  tag: $ISTIO_VERSION
+  # Istio revision to create resources with
+  revision: $REVISION
+  
+  components:
+    ingressGateways:
+    # Enable the default east-west gateway
+      - name: istio-eastwestgateway-$REVISION
+        # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+        namespace: istio-eastwest
+        enabled: true
+        label:
+          istio: eastwestgateway
+          version: $REVISION
+          app: istio-eastwestgateway
+          # Matches spec.values.global.network in the istiod deployment
+          topology.istio.io/network: $CLUSTER_NAME
+        k8s:
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+              - resource:
+                  name: cpu
+                  targetAverageUtilization: 60
+                type: Resource
+            minReplicas: 2
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-eastwestgateway-$REVISION
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 40Mi
+          env:
+            # Required by Gloo Mesh for east/west routing
+            - name: ISTIO_META_ROUTER_MODE
+              value: "sni-dnat"
+          service:
+            # Create a ClusterIP service for this gateway, because a LoadBalancer service is created separately
+            type: ClusterIP
+            # Match the LoadBalancer service
+            ports:
+              # Health check port. For AWS ELBs, this port must be listed first.
+              - name: status-port
+                port: 15021
+                targetPort: 15021
+              # Port for multicluster mTLS passthrough; required for Gloo Mesh east/west routing
+              - port: 15443
+                targetPort: 15443
+                # Gloo Mesh looks for this default name 'tls' on an ingress gateway
+                name: tls
+          overlays:
+            # Update role binding to use shared service account
+            - apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              name: istio-eastwestgateway-$REVISION-sds
+              patches:
+                - path: subjects.[0]
+                  value:
+                    name: "istio-eastwestgateway"
+                    kind: ServiceAccount
+            - apiVersion: apps/v1
+              kind: Deployment
+              name: istio-eastwestgateway-$REVISION
+              patches:
+                # Update the deployment to use shared service account
+                - path: spec.template.spec.serviceAccountName
+                  value: "istio-eastwestgateway"
+                - path: spec.template.spec.serviceAccount
+                  value: "istio-eastwestgateway"
+                # Sleep 25s on pod shutdown to allow connections to drain
+                - path: spec.template.spec.containers.[name:istio-proxy].lifecycle
+                  value:
+                    preStop:
+                      exec:
+                        command:
+                        - sleep
+                        - "25"
+                # Schedule pods on separate nodes if possible
+                - path: spec.template.spec.affinity
+                  value:
+                    podAntiAffinity:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                      - podAffinityTerm:
+                          labelSelector:
+                            matchExpressions:
+                            - key: app
+                              operator: In
+                              values:
+                              - istio-eastwestgateway-$REVISION
+                          topologyKey: kubernetes.io/hostname
+                        weight: 100
+
+  # Helm values overrides
+  values:
+    # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
+    global:
+      # Required for connecting VirtualMachines to the mesh
+      network: $CLUSTER_NAME
+      # Required for annotating Istio metrics with the cluster name.
+      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      multiCluster:
+        clusterName: $CLUSTER_NAME

--- a/istio-install/1.12/ingress-gateway-lb.yaml
+++ b/istio-install/1.12/ingress-gateway-lb.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingressgateway
+  # Deploy to the ingress gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-ingress
+spec:
+  type: LoadBalancer
+  selector:
+    istio: ingressgateway
+    version: $REVISION
+  ports:
+  # Health check port. For AWS ELBs, this port must be listed first.
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+  # Main HTTP ingress port
+  - port: 80
+    targetPort: 8080
+    name: http2
+  # Main HTTPS ingress port
+  - port: 443
+    targetPort: 8443
+    name: https

--- a/istio-install/1.12/ingress-gateway.yaml
+++ b/istio-install/1.12/ingress-gateway.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingressgateway
+  # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-ingress
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: ingress-gateway-$REVISION
+  # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+  namespace: istio-ingress
+spec:
+  # No control plane components are installed
+  profile: empty
+  # Solo.io Istio distribution repository; required for Gloo Mesh Istio. You get the repo key from your Solo Account Representative.
+  hub: $REPO
+  # The Solo.io Gloo Mesh Istio tag
+  tag: $ISTIO_VERSION
+  # Istio revision to create resources with
+  revision: $REVISION
+  
+  components:
+    ingressGateways:
+    # Enable the default ingress gateway
+      - name: istio-ingressgateway-$REVISION
+        # Deploy to the east-west gateway namespace. If using one namespace for gateways, specify 'istio-gateways' instead.
+        namespace: istio-ingress
+        enabled: true
+        label:
+          istio: ingressgateway
+          version: $REVISION
+          app: istio-ingressgateway
+          # Matches spec.values.global.network in the istiod deployment
+          topology.istio.io/network: $CLUSTER_NAME
+        k8s:
+          hpaSpec:
+            maxReplicas: 5
+            metrics:
+              - resource:
+                  name: cpu
+                  targetAverageUtilization: 60
+                type: Resource
+            minReplicas: 2
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: istio-ingressgateway-$REVISION
+          strategy:
+            rollingUpdate:
+              maxSurge: 100%
+              maxUnavailable: 25%
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 40Mi
+          env:
+            # Required by Gloo Mesh for east/west routing
+            - name: ISTIO_META_ROUTER_MODE
+              value: "sni-dnat"
+          service:
+            # Create a ClusterIP service for this gateway, because a LoadBalancer service is created separately
+            type: ClusterIP
+            # Match the LoadBalancer service
+            ports:
+              # Health check port. For AWS ELBs, this port must be listed first.
+              - name: status-port
+                port: 15021
+                targetPort: 15021
+              # Main HTTP ingress port
+              - port: 80
+                targetPort: 8080
+                name: http2
+              # Main HTTPS ingress port
+              - port: 443
+                targetPort: 8443
+                name: https
+          overlays:
+            # Update role binding to use shared service account
+            - apiVersion: rbac.authorization.k8s.io/v1
+              kind: RoleBinding
+              name: istio-ingressgateway-$REVISION-sds
+              patches:
+                - path: subjects.[0]
+                  value:
+                    name: "istio-ingressgateway"
+                    kind: ServiceAccount
+            - apiVersion: v1
+              kind: Deployment
+              name: istio-ingressgateway-$REVISION
+              patches:
+              # Update the deployment to use shared service account
+              - path: spec.template.spec.serviceAccountName
+                value: "istio-ingressgateway"
+              - path: spec.template.spec.serviceAccount
+                value: "istio-ingressgateway"
+              # Sleep 25s on pod shutdown to allow connections to drain
+              - path: spec.template.spec.containers.[name:istio-proxy].lifecycle
+                value:
+                  preStop:
+                    exec:
+                      command:
+                      - sleep
+                      - "25"
+              # Schedule pods on separate nodes if possible
+              - path: spec.template.spec.affinity
+                value:
+                  podAntiAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - podAffinityTerm:
+                        labelSelector:
+                          matchExpressions:
+                          - key: app
+                            operator: In
+                            values:
+                            - istio-ingressgateway-$REVISION
+                        topologyKey: kubernetes.io/hostname
+                      weight: 100
+
+  # Helm values overrides
+  values:
+    # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
+    global:
+      # Required for connecting VirtualMachines to the mesh
+      network: $CLUSTER_NAME
+      # Required for annotating Istio metrics with the cluster name.
+      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      multiCluster:
+        clusterName: $CLUSTER_NAME

--- a/istio-install/1.12/istiod-kubernetes.yaml
+++ b/istio-install/1.12/istiod-kubernetes.yaml
@@ -1,0 +1,117 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: production-istio
+  namespace: istio-system
+spec:
+  # Only the control plane components are installed (https://istio.io/latest/docs/setup/additional-setup/config-profiles/)
+  profile: minimal
+  # Solo.io Istio distribution repository; required for Gloo Mesh Istio. You get the repo key from your Solo Account Representative.
+  hub: $REPO
+  # Any Solo.io Gloo Mesh Istio tag
+  tag: $ISTIO_VERSION
+  # Istio revision to create resources with
+  revision: $REVISION
+
+  # Mesh configuration
+  meshConfig:
+    # Enable access logging. Empty value disables access logging.
+    # accessLogFile: /dev/stdout
+    # Encoding for the proxy access log (TEXT or JSON). Default value is TEXT.
+    accessLogEncoding: JSON
+
+    enableTracing: false
+
+    defaultConfig:
+      # Wait for the istio-proxy to start before starting application pods
+      holdApplicationUntilProxyStarts: true
+      # Enable Gloo Mesh metrics service. Required for Gloo Mesh Dashboard
+      envoyMetricsService:
+        address: enterprise-agent.gloo-mesh:9977
+      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      envoyAccessLogService:
+        address: enterprise-agent.gloo-mesh:9977
+      proxyMetadata:
+        # Enable Istio agent to handle DNS requests for known hosts
+        # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
+        ISTIO_META_DNS_CAPTURE: "true"
+        # Enable automatic address allocation (for proxy-dns)
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh Dashboard
+        # Must match the trustDomain
+        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
+
+    # Set the default behavior of the sidecar for handling outbound traffic from the application
+    outboundTrafficPolicy:
+      mode: ALLOW_ANY
+    # The trust root of a system, which is the name of the cluster that corresponds with the CA certificate CommonName identity
+    trustDomain: $CLUSTER_NAME
+    # The administrative root namespace for Istio configuration
+    rootNamespace: istio-config
+
+  # Traffic management
+  components:
+    pilot:
+      enabled: true
+      k8s:
+        # Recommended to be >1 in production
+        replicaCount: 2
+        # The Istio load tests mesh consists of 1000 services and 2000 sidecars with 70,000 mesh-wide requests per second and Istiod used 1 vCPU and 1.5 GB of memory.
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+        # Recommended to scale istiod under load
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 2
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: istiod-$REVISION
+          metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 60
+              type: Resource
+        env:
+         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
+            value: "true"
+
+    # Istio Gateway feature
+    # Disable gateways deployments, which are deployed in separate IstioOperator configurations
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: false
+    - name: istio-eastwestgateway
+      enabled: false
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: false
+
+  # Helm values overrides
+  values:
+    # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
+    global:
+      # Required for connecting VirtualMachines to the mesh
+      network: $CLUSTER_NAME
+      # Required for annotating Istio metrics with the cluster name.
+      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      multiCluster:
+        clusterName: $CLUSTER_NAME
+      # Sidecar resource settings
+      # proxy:
+      # The Istio load tests mesh consists of 1000 services and 2000 sidecars with 70,000 mesh-wide requests per second and istio-proxy used 0.35 vCPU and 40 MB memory per 1000 requests per second.
+      #   resources:
+      #     requests:
+      #       cpu: 100m
+      #       memory: 128Mi
+      #     limits: 
+      #       cpu: 2000m
+      #       memory: 1024Mi
+      #   logLevel: warning

--- a/istio-install/1.12/istiod-openshift.yaml
+++ b/istio-install/1.12/istiod-openshift.yaml
@@ -1,0 +1,144 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: production-istio
+  namespace: istio-system
+spec:
+  # Only the control plane components are installed (https://istio.io/latest/docs/setup/additional-setup/config-profiles/)
+  profile: minimal
+  # Solo.io Istio distribution repository; required for Gloo Mesh Istio. You get the repo key from your Solo Account Representative.
+  hub: $REPO
+  # Any Solo.io Gloo Mesh Istio tag
+  tag: $ISTIO_VERSION
+  # Istio revision to create resources with
+  revision: $REVISION
+
+  # Mesh configuration
+  meshConfig:
+    # Enable access logging. Empty value disables access logging.
+    # accessLogFile: /dev/stdout
+    # Encoding for the proxy access log (TEXT or JSON). Default value is TEXT.
+    accessLogEncoding: JSON
+
+    enableTracing: false
+
+    defaultConfig:
+      # Wait for the istio-proxy to start before starting application pods
+      holdApplicationUntilProxyStarts: true
+      # Enable Gloo Mesh metrics service. Required for Gloo Mesh Dashboard
+      envoyMetricsService:
+        address: enterprise-agent.gloo-mesh:9977
+      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      envoyAccessLogService:
+        address: enterprise-agent.gloo-mesh:9977
+      proxyMetadata:
+        # Enable Istio agent to handle DNS requests for known hosts
+        # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
+        ISTIO_META_DNS_CAPTURE: "true"
+        # Enable automatic address allocation (for proxy-dns)
+        ISTIO_META_DNS_AUTO_ALLOCATE: "true"
+        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh Dashboard
+        # Must match the trustDomain
+        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
+
+    # Set the default behavior of the sidecar for handling outbound traffic from the application
+    outboundTrafficPolicy:
+      mode: ALLOW_ANY
+    # The trust root of a system, which is the name of the cluster that corresponds with the CA certificate CommonName identity
+    trustDomain: $CLUSTER_NAME
+    # The administrative root namespace for Istio configuration
+    rootNamespace: istio-config
+
+  # Traffic management
+  components:
+    base:
+      enabled: true
+    pilot:
+      enabled: true
+      k8s:
+        # Recommended to be >1 in production
+        replicaCount: 2
+        # The Istio load tests mesh consists of 1000 services and 2000 sidecars with 70,000 mesh-wide requests per second and Istiod used 1 vCPU and 1.5 GB of memory.
+        resources:
+          requests:
+            cpu: 200m
+            memory: 200Mi
+        strategy:
+          rollingUpdate:
+            maxSurge: 100%
+            maxUnavailable: 25%
+        # Recommended to scale istiod under load
+        hpaSpec:
+          maxReplicas: 5
+          minReplicas: 2
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            # matches the format istiod-<revision_label>
+            name: istiod-$REVISION
+          metrics:
+            - resource:
+                name: cpu
+                targetAverageUtilization: 60
+              type: Resource
+        env:
+         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
+            value: "true"
+    # Openshift requires the Istio CNI feature to be enabled
+    cni:
+      enabled: true
+      namespace: kube-system
+      k8s:
+        overlays:
+          - kind: DaemonSet
+            name: istio-cni-node
+            patches:
+              - path: spec.template.spec.containers[0].securityContext.privileged
+                value: true
+
+    # Istio Gateway feature
+    # Disable gateways deployments, which are deployed in separate IstioOperator configurations
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: false
+    - name: istio-eastwestgateway
+      enabled: false
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: false
+
+  # Helm values overrides
+  values:
+    # CNI options for OpenShift
+    cni:
+      cniBinDir: /var/lib/cni/bin
+      cniConfDir: /etc/cni/multus/net.d
+      chained: false
+      cniConfFileName: "istio-cni.conf"
+      excludeNamespaces:
+       - istio-system
+       - kube-system
+      logLevel: info
+    sidecarInjectorWebhook:
+      injectedAnnotations:
+        k8s.v1.cni.cncf.io/networks: istio-cni
+    # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
+    global:
+      # Required for connecting VirtualMachines to the mesh
+      network: $CLUSTER_NAME
+      # Required for annotating Istio metrics with the cluster name.
+      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      multiCluster:
+        clusterName: $CLUSTER_NAME
+      # Sidecar resource settings
+      # proxy:
+      # The Istio load tests mesh consists of 1000 services and 2000 sidecars with 70,000 mesh-wide requests per second and istio-proxy used 0.35 vCPU and 40 MB memory per 1000 requests per second.
+      #   resources:
+      #     requests:
+      #       cpu: 100m
+      #       memory: 128Mi
+      #     limits: 
+      #       cpu: 2000m
+      #       memory: 1024Mi
+      #   logLevel: warning

--- a/istio-install/README.md
+++ b/istio-install/README.md
@@ -11,7 +11,7 @@ For more information about the content of the provided `IstioOperator` examples,
 
 ## Contents
 
-These resources are configured with production-level settings; however, depending on your environment, you might need to edit settings to achieve specific Istio functionality. For instructions on how to install Istio for use with Gloo Mesh Enterprise, see [Install Istio](https://docs.solo.io/gloo-mesh-enterprise/latest/setup/istio/).
+These resources are configured with production-level settings; however, depending on your environment, you might need to edit settings to achieve specific Istio functionality. For instructions on how to install Istio for use with Gloo Mesh Enterprise, see [Install Istio](https://docs.solo.io/gloo-mesh-enterprise/latest/setup/istio/). For information about the supported Istio versions for each Gloo Mesh Enterprise version, see [Supported versions](https://docs.solo.io/gloo-mesh-enterprise/latest/reference/version/versions/).
 
 - The `istiod-kubernetes.yaml` and `istiod-openshift.yaml` files provide example production-level settings for the `IstioOperator` resource to install the istiod control plane in a cluster. Choose the resource for your cluster's container orchestration platform.
 - The `ingress-gateway.yaml` file provides an `IstioOperator` resource for the ingress gateway deployment and a service account for the ingress gateway deployment to use. Note that these gateway resources are deployed to the `istio-ingress` namespace. If use only [one namespaces](https://docs.solo.io/gloo-mesh-enterprise/main/setup/istio/namespaces/) for all gateways, be sure to specify `istio-gateways` for the resource namespaces instead.


### PR DESCRIPTION
Supported for GME 1.13 (still currently in beta but available in the "main" docs branch).

Adjusted Solo.io Istio distribution repository to use $REPO variable

Removed cluster name comment at the top of some files, as there are now several variables the user would have to adjust.