### PR TITLE
Fixing relay cert names

### DIFF
--- a/helm-install/1.2/values-data-plane.yaml
+++ b/helm-install/1.2/values-data-plane.yaml
@@ -15,7 +15,7 @@ relay:
     namespace: gloo-mesh
   # Custom certs: Reference to a secret containing TLS certs used to secure the networking gRPC server with TLS.
   clientCertSecret:
-    name: enterprise-agent-$REMOTE_CLUSTER-tls-cert
+    name: relay-client-tls-secret
     namespace: gloo-mesh
   # Default self-signed certs: Reference to a secret containing a shared token for authenticating to the relay server
   # tokenSecret:

--- a/helm-install/1.2/values-mgmt-plane.yaml
+++ b/helm-install/1.2/values-mgmt-plane.yaml
@@ -27,7 +27,7 @@ enterprise-networking:
     namespace: gloo-mesh
   # Custom certs: Reference to a secret containing TLS certificates used to secure the networking gRPC server with TLS
   relayTlsSecret:
-    name: enterprise-networking-server-tls-cert
+    name: relay-server-tls-secret
     namespace: gloo-mesh
   # (NOT needed with ACM certs) Secret containing a shared token for authenticating relay agents when they first communicate with the management plane
   # tokenSecret:

--- a/helm-install/1.3/values-data-plane.yaml
+++ b/helm-install/1.3/values-data-plane.yaml
@@ -15,7 +15,7 @@ relay:
     namespace: gloo-mesh
   # Custom certs: Reference to a secret containing TLS certs used to secure the networking gRPC server with TLS.
   clientCertSecret:
-    name: enterprise-agent-$REMOTE_CLUSTER-tls-cert
+    name: relay-client-tls-secret
     namespace: gloo-mesh
   # Default self-signed certs: Reference to a secret containing a shared token for authenticating to the relay server
   # tokenSecret:

--- a/helm-install/1.3/values-mgmt-plane.yaml
+++ b/helm-install/1.3/values-mgmt-plane.yaml
@@ -27,7 +27,7 @@ enterprise-networking:
     namespace: gloo-mesh
   # Custom certs: Reference to a secret containing TLS certificates used to secure the networking gRPC server with TLS
   relayTlsSecret:
-    name: enterprise-networking-server-tls-cert
+    name: relay-server-tls-secret
     namespace: gloo-mesh
   # (NOT needed with ACM certs) Secret containing a shared token for authenticating relay agents when they first communicate with the management plane
   # tokenSecret:


### PR DESCRIPTION
From public Slack:

ok. I found the issue: the dashboard expects the secret that has the certificate of the enterprise-networking to be named relay-server-tls-secret

Does the dasbboard has any argument so I can configure the secret name containing the certificate?

Denis Jannot:
No, you can't change the secret name currently

Related change to GME docs here: https://github.com/solo-io/gloo-mesh-enterprise/pull/2420/commits/d21a6a19a47795cf971cface2d0179d264797673