### PR TITLE
Rename example cluster-1 to cluster1

### DIFF
--- a/virtual-gateway/v1-api/1-ingress-gateway/1.1-basic-single-cluster.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.1-basic-single-cluster.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -30,9 +30,9 @@ spec:
     destinationSelectors:                # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway     # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway     # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
+          clusterName: cluster1
   connectionHandlers:
   - http:
       routeConfig:
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/1-ingress-gateway/1.2.1-multi-gateway-label-selector.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.2.1-multi-gateway-label-selector.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/1-ingress-gateway/1.2.2-multi-gateway-cluster-selector.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.2.2-multi-gateway-cluster-selector.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -31,12 +31,12 @@ spec:
     destinationSelectors:
     - kubeServiceRefs:                   # select single specific kubernetes services
         services:
-        - name: istio-ingressgateway     # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway     # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
-        - name: istio-ingressgateway     # select cluster-2 ingress gateway service
+          clusterName: cluster1
+        - name: istio-ingressgateway     # select cluster2 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-2
+          clusterName: cluster2
   connectionHandlers:
   - http:
       routeConfig:
@@ -48,7 +48,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/1-ingress-gateway/1.2.3-multi-cluster-multi-gateway.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.2.3-multi-cluster-multi-gateway.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -31,14 +31,14 @@ spec:
     destinationSelectors:                # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway     # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway     # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
+          clusterName: cluster1
     - kubeServiceRefs:                   # select single specific kubernetes services
         services: 
-        - name: istio-ingressgateway     # select cluster-2 ingress gateway service
+        - name: istio-ingressgateway     # select cluster2 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-2
+          clusterName: cluster2
   connectionHandlers:
   - http:
       routeConfig:
@@ -50,7 +50,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/1-ingress-gateway/1.3-multi-gateway-multiple-cluster.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.3-multi-gateway-multiple-cluster.yaml
@@ -15,15 +15,15 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualGateway
 metadata:
-  name: ingress-cluster-1
+  name: ingress-cluster1
   namespace: gloo-mesh
 spec:
   ingressGatewaySelectors:
@@ -31,9 +31,9 @@ spec:
     destinationSelectors:               # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway    # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway    # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
+          clusterName: cluster1
   connectionHandlers:
   - http:
       routeConfig:
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1 # route to cluster-1 frontend application
+                  clusterName: cluster1 # route to cluster1 frontend application
                   name: frontend
                   namespace: app
                   port: 8080
@@ -53,7 +53,7 @@ spec:
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualGateway
 metadata:
-  name: ingress-cluster-2
+  name: ingress-cluster2
   namespace: gloo-mesh
 spec:
   ingressGatewaySelectors:
@@ -61,9 +61,9 @@ spec:
     destinationSelectors:                # select single specific kubernetes services
     - kubeServiceRefs:                   # select single specific kubernetes services
         services: 
-        - name: istio-ingressgateway     # select cluster-2 ingress gateway service
+        - name: istio-ingressgateway     # select cluster2 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-2
+          clusterName: cluster2
   connectionHandlers:
   - http:
       routeConfig:
@@ -75,7 +75,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-2 # route to cluster-2 frontend application
+                  clusterName: cluster2 # route to cluster2 frontend application
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/1-ingress-gateway/1.4-multi-gateway-label-selector.yaml
+++ b/virtual-gateway/v1-api/1-ingress-gateway/1.4-multi-gateway-label-selector.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1 # route to cluster-1 frontend application
+                  clusterName: cluster1 # route to cluster1 frontend application
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.1.1-route-delay.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.1.1-route-delay.yaml
@@ -17,9 +17,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.1.2-host-delay.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.1.2-host-delay.yaml
@@ -17,9 +17,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.2.1-route-abort.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.2.1-route-abort.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.2.2-host-abort.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.2.2-host-abort.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.3.1-route-abort-percent.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.3.1-route-abort-percent.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/10-fault-injection/10.3.2-host-abort-percent.yaml
+++ b/virtual-gateway/v1-api/10-fault-injection/10.3.2-host-abort-percent.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -45,7 +45,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/11-timeouts/11.1.1-route-timeout.yaml
+++ b/virtual-gateway/v1-api/11-timeouts/11.1.1-route-timeout.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/11-timeouts/11.1.2-host-timeout.yaml
+++ b/virtual-gateway/v1-api/11-timeouts/11.1.2-host-timeout.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/11-timeouts/11.2.1-route-retries.yaml
+++ b/virtual-gateway/v1-api/11-timeouts/11.2.1-route-retries.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/11-timeouts/11.2.2-host-retries.yaml
+++ b/virtual-gateway/v1-api/11-timeouts/11.2.2-host-retries.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.1.1-route-allowed-origins.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.1.1-route-allowed-origins.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.1.2-host-allowed-origins.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.1.2-host-allowed-origins.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.2.1-route-allowed-methods-headers.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.2.1-route-allowed-methods-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.2.2-host-allowed-methods-headers.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.2.2-host-allowed-methods-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.3.1-route-exposed-headers.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.3.1-route-exposed-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.3.2-host-exposed-headers.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.3.2-host-exposed-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.4.1-route-preflight-request-caching.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.4.1-route-preflight-request-caching.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.4.2-host-preflight-request-caching.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.4.2-host-preflight-request-caching.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.5.1-route-allow-credentials.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.5.1-route-allow-credentials.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/12-cors/12.5.2-host-allow-credentials.yaml
+++ b/virtual-gateway/v1-api/12-cors/12.5.2-host-allow-credentials.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/13-mirroring/13.1.1-route-mirroring.yaml
+++ b/virtual-gateway/v1-api/13-mirroring/13.1.1-route-mirroring.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,16 +44,16 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
             options:
               trafficPolicy:
-                mirror:                  # mirror 50% traffic from cluster-1 frontend to cluster-2
+                mirror:                  # mirror 50% traffic from cluster1 frontend to cluster2
                   port: 8080
                   percentage: 50
                   kubeService:
-                    clusterName: cluster-2
+                    clusterName: cluster2
                     name: frontend
                     namespace: app

--- a/virtual-gateway/v1-api/13-mirroring/13.1.2-host-mirroring.yaml
+++ b/virtual-gateway/v1-api/13-mirroring/13.1.2-host-mirroring.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,16 +44,16 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
             options:
               trafficPolicy:
-                mirror:                  # mirror 50% traffic from cluster-1 frontend to cluster-2
+                mirror:                  # mirror 50% traffic from cluster1 frontend to cluster2
                   port: 8080
                   percentage: 50
                   kubeService:
-                    clusterName: cluster-2
+                    clusterName: cluster2
                     name: frontend
                     namespace: app

--- a/virtual-gateway/v1-api/14-outlier-detection/14.1-outlier-detection.yaml
+++ b/virtual-gateway/v1-api/14-outlier-detection/14.1-outlier-detection.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/15-mtls-settings/15.1-mtls-settings.yaml
+++ b/virtual-gateway/v1-api/15-mtls-settings/15.1-mtls-settings.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: discovery.mesh.gloo.solo.io/v1

--- a/virtual-gateway/v1-api/16-csrf/16.1-csrf-enabled.yaml
+++ b/virtual-gateway/v1-api/16-csrf/16.1-csrf-enabled.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/16-csrf/16.2-csrf-shadow-enabled.yaml
+++ b/virtual-gateway/v1-api/16-csrf/16.2-csrf-shadow-enabled.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/2-connection-handling/2.2-tls-termination.yaml
+++ b/virtual-gateway/v1-api/2-connection-handling/2.2-tls-termination.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/2-connection-handling/2.3-https-redirect.yaml
+++ b/virtual-gateway/v1-api/2-connection-handling/2.3-https-redirect.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -70,7 +70,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/2-connection-handling/2.5-sni-matching.yaml
+++ b/virtual-gateway/v1-api/2-connection-handling/2.5-sni-matching.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,5 +49,5 @@ spec:
           kube:
             name: frontend
             namespace: app
-            clusterName: cluster-1
+            clusterName: cluster1
             port: 8080

--- a/virtual-gateway/v1-api/2-connection-handling/2.6-sni-wildcard-matching.yaml
+++ b/virtual-gateway/v1-api/2-connection-handling/2.6-sni-wildcard-matching.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,5 +49,5 @@ spec:
           kube:
             name: frontend
             namespace: app
-            clusterName: cluster-1
+            clusterName: cluster1
             port: 8080

--- a/virtual-gateway/v1-api/2-connection-handling/2.7-proxy-protocol.yaml
+++ b/virtual-gateway/v1-api/2-connection-handling/2.7-proxy-protocol.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -46,7 +46,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/3-virtual-hosts/3.1-virtual-gateway-selection.yaml
+++ b/virtual-gateway/v1-api/3-virtual-hosts/3.1-virtual-gateway-selection.yaml
@@ -14,15 +14,15 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualGateway
 metadata:
-  name: ingress-cluster-1
+  name: ingress-cluster1
   namespace: gloo-mesh
 spec:
   ingressGatewaySelectors:
@@ -30,20 +30,20 @@ spec:
     destinationSelectors:               # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway    # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway    # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
+          clusterName: cluster1
   connectionHandlers:
   - http:
       routeConfig:
-      - virtualHostSelector:             # delegate routing to virtual hosts with label gateway: cluster-1 
+      - virtualHostSelector:             # delegate routing to virtual hosts with label gateway: cluster1 
           labels:
-            gateway: cluster-1
+            gateway: cluster1
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualGateway
 metadata:
-  name: ingress-cluster-2
+  name: ingress-cluster2
   namespace: gloo-mesh
 spec:
   ingressGatewaySelectors:
@@ -51,23 +51,23 @@ spec:
     destinationSelectors:                # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway     # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway     # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-2
+          clusterName: cluster2
   connectionHandlers:
   - http:
       routeConfig:
-      - virtualHostSelector:             # delegate routing to virtual hosts with label gateway: cluster-2
+      - virtualHostSelector:             # delegate routing to virtual hosts with label gateway: cluster2
           labels:
-            gateway: cluster-2
+            gateway: cluster2
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualHost
 metadata:
   name: frontend
   namespace: gloo-mesh
-  labels:                                # applies to ingress-cluster-1 virtualGateway
-    gateway: cluster-1
+  labels:                                # applies to ingress-cluster1 virtualGateway
+    gateway: cluster1
 spec:
   domains:
   - api.solo.io
@@ -76,7 +76,7 @@ spec:
     routeAction:
       destinations:
       - kubeService:
-          clusterName: cluster-1         # route to cluster-1 frontend
+          clusterName: cluster1         # route to cluster1 frontend
           name: frontend
           namespace: app
           port: 8080
@@ -86,8 +86,8 @@ kind: VirtualHost
 metadata:
   name: frontend
   namespace: gloo-mesh
-  labels:                                # applies to ingress-cluster-2 virtualGateway
-    gateway: cluster-2
+  labels:                                # applies to ingress-cluster2 virtualGateway
+    gateway: cluster2
 spec:
   domains:
   - api.solo.io
@@ -96,7 +96,7 @@ spec:
     routeAction:
       destinations:
       - kubeService:
-          clusterName: cluster-2         # route to cluster-2 frontend
+          clusterName: cluster2         # route to cluster2 frontend
           name: frontend
           namespace: app
           port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.1.1-prefix-path-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.1.1-prefix-path-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.1.2-exact-path-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.1.2-exact-path-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.1.3-regex-path-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.1.3-regex-path-match.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,7 +49,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.1.4-suffix-path-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.1.4-suffix-path-match.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,7 +49,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.1.5-prefix-ignore-case-path-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.1.5-prefix-ignore-case-path-match.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -50,7 +50,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.2.1-header-name-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.2.1-header-name-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.2.2-header-value-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.2.2-header-value-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -43,24 +43,24 @@ spec:
           - matchers:                    # route to specific cluster
             - headers:
               - name: x-frontend-app
-                value: cluster-1
+                value: cluster1
             name: frontend
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
           - matchers:                    # route to specific cluster
             - headers:
               - name: x-frontend-app
-                value: cluster-2
+                value: cluster2
             name: frontend
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.2.3-header-value-regex-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.2.3-header-value-regex-match.yaml
@@ -2,8 +2,8 @@
 # Test Name: Header Regex Value Match
 # Test Number: 4.2.3
 # Test Description:
-#   - Route X-frontend-app header value cluster-1 to cluster-1 frontend
-#   - Route X-frontend-app header value cluster-* to cluster-2 frontend
+#   - Route X-frontend-app header value cluster1 to cluster1 frontend
+#   - Route X-frontend-app header value cluster-* to cluster2 frontend
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,25 +44,25 @@ spec:
           - matchers:                    # route to specific cluster
             - headers:
               - name: X-frontend-app
-                value: cluster-1
-            name: frontend-cluster-1
+                value: cluster1
+            name: frontend-cluster1
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
-          - matchers:                    # anything other than cluster-1 be routed to cluster-2
+          - matchers:                    # anything other than cluster1 be routed to cluster2
             - headers:
               - name: X-frontend-app
                 value: cluster-.*
                 regex: true              # enable regex support
-            name: frontend-cluster-2
+            name: frontend-cluster2
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.2.4-header-value-invert-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.2.4-header-value-invert-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,7 +49,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.3.1-query-value-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.3.1-query-value-match.yaml
@@ -2,7 +2,7 @@
 # Test Name: Query Value Match
 # Test Number: 4.3.1
 # Test Description:
-#   - Route based on cluster query value in ?cluster=<cluster-1|cluster-2>
+#   - Route based on cluster query value in ?cluster=<cluster1|cluster2>
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -40,27 +40,27 @@ spec:
           domains:
           - "api.solo.io"
           routes:
-          - matchers:                    # match ?cluster=cluster-1
+          - matchers:                    # match ?cluster=cluster1
             - queryParameters:
               - name: cluster
-                value: cluster-1
+                value: cluster1
             name: frontend
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
-          - matchers:                    # match ?cluster=cluster-2
+          - matchers:                    # match ?cluster=cluster2
             - queryParameters:
               - name: cluster
-                value: cluster-2
+                value: cluster2
             name: frontend
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.3.2-query-value-regex-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.3.2-query-value-regex-match.yaml
@@ -2,8 +2,8 @@
 # Test Name: Query Value Regex Value Match
 # Test Number: 4.3.2
 # Test Description:
-# - Requests that contain ?cluster=cluster-1 to cluster-1
-# - Requests that contain ?cluster=cluster-* to cluster-2
+# - Requests that contain ?cluster=cluster1 to cluster1
+# - Requests that contain ?cluster=cluster-* to cluster2
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -41,15 +41,15 @@ spec:
           domains:
           - "api.solo.io"
           routes:
-          - matchers:                    # match ?cluster=cluster-1
+          - matchers:                    # match ?cluster=cluster1
             - queryParameters:
               - name: cluster
-                value: cluster-1
+                value: cluster1
             name: frontend
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
@@ -62,7 +62,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/4-route-matching/4.4-method-match.yaml
+++ b/virtual-gateway/v1-api/4-route-matching/4.4-method-match.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -46,7 +46,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.1-single-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.1-single-destination.yaml
@@ -2,7 +2,7 @@
 # Test Name: Simple Destination Routing
 # Test Number: 5.1
 # Test Description:
-#   - Route all requests to frontend application in cluster-1
+#   - Route all requests to frontend application in cluster1
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.10.1-add-destination-response-headers.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.10.1-add-destination-response-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.10.2-remove-destination-response-header.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.10.2-remove-destination-response-header.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.11.1-add-route-request-headers.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.11.1-add-route-request-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.11.2-remove-route-request-header.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.11.2-remove-route-request-header.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.12.1-add-route-response-headers.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.12.1-add-route-response-headers.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.12.2-remove-route-response-header.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.12.2-remove-route-response-header.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.2-weighted-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.2-weighted-destination.yaml
@@ -2,8 +2,8 @@
 # Test Name: Weighted Destination Routing
 # Test Number: 5.2
 # Test Description:
-#   - Route 80% of requests to frontend application in cluster-1
-#   - Route 20% of requests to frontend application in cluster-2
+#   - Route 80% of requests to frontend application in cluster1
+#   - Route 20% of requests to frontend application in cluster2
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,15 +44,15 @@ spec:
           - name: frontend
             routeAction:
               destinations:
-              - weight: 80               # route 80% of traffic to frontend in cluster-2
+              - weight: 80               # route 80% of traffic to frontend in cluster2
                 kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
-              - weight: 20               # route 20% of traffic to frontend in cluster-2
+              - weight: 20               # route 20% of traffic to frontend in cluster2
                 kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.4-multi-cluster-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.4-multi-cluster-destination.yaml
@@ -2,7 +2,7 @@
 # Test Name: Multi Cluster Destination Routing
 # Test Number: 5.4
 # Test Description:
-#   - Route all requests to frontend application in cluster-1 and cluster-2
+#   - Route all requests to frontend application in cluster1 and cluster2
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -42,14 +42,14 @@ spec:
           routes:
           - name: frontend
             routeAction:
-              destinations:              # route to both cluster-1 and cluster-2 frontend
+              destinations:              # route to both cluster1 and cluster2 frontend
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
               - kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.5-cluster-header-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.5-cluster-header-destination.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,16 +44,16 @@ spec:
           routes:
           - name: frontend
             routeAction:
-              destinations:              # route to both cluster-1 and cluster-2 frontend
+              destinations:              # route to both cluster1 and cluster2 frontend
               - clusterHeader: X-SOLO-CLUSTER  # 
                 kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
               - clusterHeader: X-SOLO-CLUSTER
                 kubeService:
-                  clusterName: cluster-2
+                  clusterName: cluster2
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.6-subset-routing.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.6-subset-routing.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,7 +49,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080
@@ -62,7 +62,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.7-virtual-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.7-virtual-destination.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1

--- a/virtual-gateway/v1-api/5-destination-routing/5.8-static-destination.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.8-static-destination.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: discovery.mesh.gloo.solo.io/v1

--- a/virtual-gateway/v1-api/5-destination-routing/5.9.1-add-destination-request-headers.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.9.1-add-destination-request-headers.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -46,7 +46,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/5-destination-routing/5.9.2-remove-destination-request-header.yaml
+++ b/virtual-gateway/v1-api/5-destination-routing/5.9.2-remove-destination-request-header.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,7 +44,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.1-host-redirect.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.1-host-redirect.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -51,7 +51,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.2-path-redirect.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.2-path-redirect.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -53,7 +53,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.3-prefix-rewrite.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.3-prefix-rewrite.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -49,7 +49,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.4-modify-response-code.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.4-modify-response-code.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.5-https-redirect.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.5-https-redirect.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -77,7 +77,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/6-redirects/6.6-strip-query.yaml
+++ b/virtual-gateway/v1-api/6-redirects/6.6-strip-query.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v1-api/7-direct-response/7.1-direct-response.yaml
+++ b/virtual-gateway/v1-api/7-direct-response/7.1-direct-response.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1

--- a/virtual-gateway/v1-api/8-route-delegation/8.1-namespace-selector.yaml
+++ b/virtual-gateway/v1-api/8-route-delegation/8.1-namespace-selector.yaml
@@ -2,8 +2,8 @@
 # Test Name: Namespace Based Delegation
 # Test Number: 8.1
 # Test Description:
-#   - Delegate cluster-1.solo.io to cluster-1 RouteTable
-#   - Delegate cluster-2.solo.io to cluster-2 RouteTable
+#   - Delegate cluster1.solo.io to cluster1 RouteTable
+#   - Delegate cluster2.solo.io to cluster2 RouteTable
 ##################################################
 apiVersion: v1
 kind: Namespace
@@ -13,12 +13,12 @@ metadata:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-1-routes
+  name: cluster1-routes
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cluster-2-routes
+  name: cluster2-routes
 
 ---
 apiVersion: networking.mesh.gloo.solo.io/v1
@@ -31,9 +31,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -60,50 +60,50 @@ spec:
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualHost
 metadata:
-  name: cluster-1
+  name: cluster1
   namespace: virtual-hosts
   labels:
     gateway: ingress
 spec:
   domains:
-  - cluster-1.solo.io
+  - cluster1.solo.io
   routes:
-  - delegateAction:                      # domain cluster-1.solo.io applies to RouteTables in the cluster-1-routes namespace
+  - delegateAction:                      # domain cluster1.solo.io applies to RouteTables in the cluster1-routes namespace
       selector:
         namespaces:
-        - cluster-1-routes
+        - cluster1-routes
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualHost
 metadata:
-  name: cluster-2
+  name: cluster2
   namespace: virtual-hosts
   labels:
     gateway: ingress
 spec:
   domains:
-  - cluster-2.solo.io
+  - cluster2.solo.io
   routes:
-  - delegateAction:                      # domain cluster-1.solo.io applies to RouteTables in the cluster-2-routes namespace
+  - delegateAction:                      # domain cluster1.solo.io applies to RouteTables in the cluster2-routes namespace
       selector:
         namespaces:
-        - cluster-2-routes
+        - cluster2-routes
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1-routes            # matches the namespace selector in cluster-1 VirtualHost
+  namespace: cluster1-routes            # matches the namespace selector in cluster1 VirtualHost
 spec:
   routes:
   - matchers:
     - uri:
-        prefix: /frontend                # only match on cluster-1.solo.io/frontend
+        prefix: /frontend                # only match on cluster1.solo.io/frontend
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-1 frontend application
-          clusterName: cluster-1
+      - kubeService:                     # route requests to cluster1 frontend application
+          clusterName: cluster1
           name: frontend
           namespace: app
           port: 8080
@@ -112,17 +112,17 @@ apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-2-routes            # matches the namespace selector in cluster-2 VirtualHost
+  namespace: cluster2-routes            # matches the namespace selector in cluster2 VirtualHost
 spec:
   routes:
   - matchers:
     - uri:
-        prefix: /frontend                # only match on cluster-2.solo.io/frontend
+        prefix: /frontend                # only match on cluster2.solo.io/frontend
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-2 frontend application
-          clusterName: cluster-2
+      - kubeService:                     # route requests to cluster2 frontend application
+          clusterName: cluster2
           name: frontend
           namespace: app
           port: 8080

--- a/virtual-gateway/v1-api/8-route-delegation/8.2-label-selector.yaml
+++ b/virtual-gateway/v1-api/8-route-delegation/8.2-label-selector.yaml
@@ -2,8 +2,8 @@
 # Test Name: Label Selector Based Route Selection
 # Test Number: 8.2
 # Test Description:
-#   - Delegate cluster-1.solo.io to cluster-1 RouteTable
-#   - Delegate cluster-2.solo.io to cluster-2 RouteTable
+#   - Delegate cluster1.solo.io to cluster1 RouteTable
+#   - Delegate cluster2.solo.io to cluster2 RouteTable
 ##################################################
 apiVersion: networking.mesh.gloo.solo.io/v1
 kind: VirtualMesh
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -44,52 +44,52 @@ spec:
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualHost
 metadata:
-  name: cluster-1
+  name: cluster1
   namespace: gloo-mesh
   labels:
     gateway: ingress
 spec:
   domains:
-  - cluster-1.solo.io
+  - cluster1.solo.io
   routes:
-  - delegateAction:                      # domain cluster-1.solo.io applies to RouteTables with the label cluster=cluster-1 in the gloo-mesh namespace
+  - delegateAction:                      # domain cluster1.solo.io applies to RouteTables with the label cluster=cluster1 in the gloo-mesh namespace
       selector:
         labels:
-          cluster: cluster-1
+          cluster: cluster1
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: VirtualHost
 metadata:
-  name: cluster-2
+  name: cluster2
   namespace: gloo-mesh
   labels:
     gateway: ingress
 spec:
   domains:
-  - cluster-2.solo.io
+  - cluster2.solo.io
   routes:
-  - delegateAction:                      # domain cluster-1.solo.io applies to RouteTables with the label cluster=cluster-2 in the gloo-mesh namespace
+  - delegateAction:                      # domain cluster1.solo.io applies to RouteTables with the label cluster=cluster2 in the gloo-mesh namespace
       selector:
         labels:
-          cluster: cluster-2
+          cluster: cluster2
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: RouteTable
 metadata:
-  name: frontend-cluster-1
-  namespace: gloo-mesh                   # matches the namespace selector in cluster-1 VirtualHost
+  name: frontend-cluster1
+  namespace: gloo-mesh                   # matches the namespace selector in cluster1 VirtualHost
   labels:
-    cluster: cluster-1                   # matches the label selector in cluster-1 VirtualHost
+    cluster: cluster1                   # matches the label selector in cluster1 VirtualHost
 spec:
   routes:
   - matchers:
     - uri:
-        prefix: /frontend                # only match on cluster-1.solo.io/frontend
+        prefix: /frontend                # only match on cluster1.solo.io/frontend
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-1 frontend application
-          clusterName: cluster-1
+      - kubeService:                     # route requests to cluster1 frontend application
+          clusterName: cluster1
           name: frontend
           namespace: app
           port: 8080
@@ -97,20 +97,20 @@ spec:
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
 kind: RouteTable
 metadata:
-  name: frontend-cluster-2
-  namespace: gloo-mesh                   # matches the namespace selector in cluster-2 VirtualHost
+  name: frontend-cluster2
+  namespace: gloo-mesh                   # matches the namespace selector in cluster2 VirtualHost
   labels:
-    cluster: cluster-2                   # matches the label selector in cluster-2 VirtualHost
+    cluster: cluster2                   # matches the label selector in cluster2 VirtualHost
 spec:
   routes:
   - matchers:
     - uri:
-        prefix: /frontend                # only match on cluster-2.solo.io/frontend
+        prefix: /frontend                # only match on cluster2.solo.io/frontend
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-2 frontend application
-          clusterName: cluster-2
+      - kubeService:                     # route requests to cluster2 frontend application
+          clusterName: cluster2
           name: frontend
           namespace: app
           port: 8080

--- a/virtual-gateway/v1-api/8-route-delegation/8.3-weighted-routes.yaml
+++ b/virtual-gateway/v1-api/8-route-delegation/8.3-weighted-routes.yaml
@@ -15,9 +15,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@ spec:
   domains:
   - frontend.solo.io
   routes:
-  - delegateAction:                      # domain frontend.solo.io applies to RouteTables with the label cluster=cluster-1 in the gloo-mesh namespace
+  - delegateAction:                      # domain frontend.solo.io applies to RouteTables with the label cluster=cluster1 in the gloo-mesh namespace
       sortMethod: TABLE_WEIGHT           # sort the matching RouteTables by their table weight
       selector:
         labels:
@@ -74,8 +74,8 @@ spec:
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-1 frontend application
-          clusterName: cluster-1
+      - kubeService:                     # route requests to cluster1 frontend application
+          clusterName: cluster1
           name: frontend
           namespace: app
           port: 8080
@@ -92,12 +92,12 @@ spec:
   routes:
   - matchers:
     - uri:
-        prefix: /frontend/cluster-2      # only match on frontend.solo.io/frontend/cluster-2
+        prefix: /frontend/cluster2      # only match on frontend.solo.io/frontend/cluster2
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-2 frontend application
-          clusterName: cluster-2
+      - kubeService:                     # route requests to cluster2 frontend application
+          clusterName: cluster2
           name: frontend
           namespace: app
           port: 8080

--- a/virtual-gateway/v1-api/8-route-delegation/8.4-specify-route-order.yaml
+++ b/virtual-gateway/v1-api/8-route-delegation/8.4-specify-route-order.yaml
@@ -16,9 +16,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -53,7 +53,7 @@ spec:
   domains:
   - frontend.solo.io
   routes:
-  - delegateAction:                      # domain frontend.solo.io applies to RouteTables with the label cluster=cluster-1 in the gloo-mesh namespace
+  - delegateAction:                      # domain frontend.solo.io applies to RouteTables with the label cluster=cluster1 in the gloo-mesh namespace
       sortMethod: ROUTE_SPECIFICITY      # sort the matching RouteTables by their specificity
       selector:
         labels:
@@ -74,8 +74,8 @@ spec:
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-1 frontend application
-          clusterName: cluster-1
+      - kubeService:                     # route requests to cluster1 frontend application
+          clusterName: cluster1
           name: frontend
           namespace: app
           port: 8080
@@ -91,12 +91,12 @@ spec:
   routes:
   - matchers:
     - uri:
-        exact: /frontend/cluster-2       # only match on frontend.solo.io/frontend/cluster-2 (exact is more specific than prefix match)
+        exact: /frontend/cluster2       # only match on frontend.solo.io/frontend/cluster2 (exact is more specific than prefix match)
     name: frontend
     routeAction:
       destinations:
-      - kubeService:                     # route requests to cluster-2 frontend application
-          clusterName: cluster-2
+      - kubeService:                     # route requests to cluster2 frontend application
+          clusterName: cluster2
           name: frontend
           namespace: app
           port: 8080

--- a/virtual-gateway/v1-api/9-traffic-shifting/9.1-weighted-destination.yaml
+++ b/virtual-gateway/v1-api/9-traffic-shifting/9.1-weighted-destination.yaml
@@ -14,9 +14,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -47,7 +47,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v2-api/1-ingress-gateway/1.1-basic-single-cluster.yaml
+++ b/virtual-gateway/v2-api/1-ingress-gateway/1.1-basic-single-cluster.yaml
@@ -21,9 +21,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -37,9 +37,9 @@ spec:
     destinationSelectors:                # select single specific kubernetes services
     - kubeServiceRefs:
         services:
-        - name: istio-ingressgateway     # select cluster-1 ingress gateway service
+        - name: istio-ingressgateway     # select cluster1 ingress gateway service
           namespace: istio-system
-          clusterName: cluster-1
+          clusterName: cluster1
   connectionHandlers:
   - http:
       routeConfig:
@@ -51,7 +51,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080

--- a/virtual-gateway/v2-api/1-ingress-gateway/1.2.1-multi-gateway-label-selector.yaml
+++ b/virtual-gateway/v2-api/1-ingress-gateway/1.2.1-multi-gateway-label-selector.yaml
@@ -25,9 +25,9 @@ metadata:
     root-trust-policy: auto-mtls
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/10-fault-injection/10.1-delay.yaml
+++ b/virtual-gateway/v2-api/10-fault-injection/10.1-delay.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/10-fault-injection/10.2-abort.yaml
+++ b/virtual-gateway/v2-api/10-fault-injection/10.2-abort.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/10-fault-injection/10.3-abort-percent.yaml
+++ b/virtual-gateway/v2-api/10-fault-injection/10.3-abort-percent.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/11-timeouts/11.1-timeout.yaml
+++ b/virtual-gateway/v2-api/11-timeouts/11.1-timeout.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/11-timeouts/11.2-retries.yaml
+++ b/virtual-gateway/v2-api/11-timeouts/11.2-retries.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/12-cors/12.1-allowed-origins.yaml
+++ b/virtual-gateway/v2-api/12-cors/12.1-allowed-origins.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/12-cors/12.2-allowed-methods-headers.yaml
+++ b/virtual-gateway/v2-api/12-cors/12.2-allowed-methods-headers.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/12-cors/12.3-exposed-headers.yaml
+++ b/virtual-gateway/v2-api/12-cors/12.3-exposed-headers.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/12-cors/12.4-preflight-request-caching.yaml
+++ b/virtual-gateway/v2-api/12-cors/12.4-preflight-request-caching.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/12-cors/12.5-allow-credentials.yaml
+++ b/virtual-gateway/v2-api/12-cors/12.5-allow-credentials.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/13-mirroring/13.1-mirroring.yaml
+++ b/virtual-gateway/v2-api/13-mirroring/13.1-mirroring.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/14-outlier-detection/14.1-outlier-detection.yaml
+++ b/virtual-gateway/v2-api/14-outlier-detection/14.1-outlier-detection.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/15-mtls-settings/15.1-mtls-settings.yaml
+++ b/virtual-gateway/v2-api/15-mtls-settings/15.1-mtls-settings.yaml
@@ -19,9 +19,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: discovery.mesh.gloo.solo.io/v1

--- a/virtual-gateway/v2-api/16-csrf/16.1-csrf-enabled.yaml
+++ b/virtual-gateway/v2-api/16-csrf/16.1-csrf-enabled.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/16-csrf/16.2-csrf-shadow-enabled.yaml
+++ b/virtual-gateway/v2-api/16-csrf/16.2-csrf-shadow-enabled.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/2-connection-handling/2.2-tls-termination.yaml
+++ b/virtual-gateway/v2-api/2-connection-handling/2.2-tls-termination.yaml
@@ -22,9 +22,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/2-connection-handling/2.3-https-redirect.yaml
+++ b/virtual-gateway/v2-api/2-connection-handling/2.3-https-redirect.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.1.1-prefix-path-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.1.1-prefix-path-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.1.2-exact-path-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.1.2-exact-path-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.1.3-regex-path-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.1.3-regex-path-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.1.4-suffix-path-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.1.4-suffix-path-match.yaml
@@ -23,9 +23,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.1.5-prefix-ignore-case-path-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.1.5-prefix-ignore-case-path-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.2.1-header-name-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.2.1-header-name-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/4-route-matching/4.2.2-header-value-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.2.2-header-value-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -50,22 +50,22 @@ spec:
   virtualGateways:
     - name: ingress
   http:
-  - name: frontend-cluster-1
+  - name: frontend-cluster1
     matchers:
     - headers:
       - name: X-frontend-app             # match on header X-frontend-app existing
-        value: cluster-1                 # route to a specific cluster
+        value: cluster1                 # route to a specific cluster
     forwardTo:
       destinations:
       - name: frontend
         namespace: app
         port:
           number: 8080
-  - name: frontend-cluster-2
+  - name: frontend-cluster2
     matchers:
     - headers:
       - name: X-frontend-app             # match on header X-frontend-app existing
-        value: cluster-2                 # route to a specific cluster
+        value: cluster2                 # route to a specific cluster
     forwardTo:
       destinations:
       - name: frontend

--- a/virtual-gateway/v2-api/4-route-matching/4.2.3-header-value-regex-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.2.3-header-value-regex-match.yaml
@@ -3,8 +3,8 @@
 # Test Number: 4.2.3
 # API Version: 2
 # Test Description:
-#   - Route X-frontend-app header value cluster-1 to cluster-1 frontend
-#   - Route X-frontend-app header value cluster-* to cluster-2 frontend
+#   - Route X-frontend-app header value cluster1 to cluster1 frontend
+#   - Route X-frontend-app header value cluster-* to cluster2 frontend
 ##################################################
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
@@ -22,9 +22,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -51,18 +51,18 @@ spec:
   virtualGateways:
     - name: ingress
   http:
-  - name: frontend-cluster-1
+  - name: frontend-cluster1
     matchers:
     - headers:
       - name: X-frontend-app             # match on header X-frontend-app existing
-        value: cluster-1                 # route to a specific cluster
+        value: cluster1                 # route to a specific cluster
     forwardTo:
       destinations:
       - name: frontend
         namespace: app
         port:
           number: 8080
-  - name: frontend-cluster-2
+  - name: frontend-cluster2
     matchers:
     - headers:
       - name: X-frontend-app             # match on header X-frontend-app existing

--- a/virtual-gateway/v2-api/4-route-matching/4.2.4-header-value-invert-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.2.4-header-value-invert-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -50,7 +50,7 @@ spec:
   virtualGateways:
     - name: ingress
   http:
-  - name: frontend-cluster-1
+  - name: frontend-cluster1
     matchers:
     - headers:
       - name: X-route-to-frontend

--- a/virtual-gateway/v2-api/4-route-matching/4.3.1-query-value-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.3.1-query-value-match.yaml
@@ -3,7 +3,7 @@
 # Test Number: 4.3.1
 # API Version: 2
 # Test Description:
-#   - Route based on cluster query value in ?cluster=<cluster-1|cluster-2>
+#   - Route based on cluster query value in ?cluster=<cluster1|cluster2>
 # Issues
 # - https://github.com/solo-io/gloo-mesh-enterprise/issues/2077
 ##################################################
@@ -23,9 +23,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -53,10 +53,10 @@ spec:
     - name: ingress
   http:
   - name: frontend
-    matchers:                            # match ?cluster=cluster-1
+    matchers:                            # match ?cluster=cluster1
     - queryParameters:
       - name: cluster
-        value: cluster-1
+        value: cluster1
     forwardTo:
       destinations:
       - name: frontend
@@ -85,27 +85,27 @@ spec:
 #           domains:
 #           - "*"
 #           routes:
-#           - matchers:                    # match ?cluster=cluster-1
+#           - matchers:                    # match ?cluster=cluster1
 #             - queryParameters:
 #               - name: cluster
-#                 value: cluster-1
+#                 value: cluster1
 #             name: frontend
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
-#           - matchers:                    # match ?cluster=cluster-2
+#           - matchers:                    # match ?cluster=cluster2
 #             - queryParameters:
 #               - name: cluster
-#                 value: cluster-2
+#                 value: cluster2
 #             name: frontend
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-2
+#                   clusterName: cluster2
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/4-route-matching/4.3.2-query-value-regex-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.3.2-query-value-regex-match.yaml
@@ -3,8 +3,8 @@
 # Test Number: 4.3.2
 # API Version: 2
 # Test Description:
-# - Requests that contain ?cluster=cluster-1 to cluster-1
-# - Requests that contain ?cluster=cluster-* to cluster-2
+# - Requests that contain ?cluster=cluster1 to cluster1
+# - Requests that contain ?cluster=cluster-* to cluster2
 # Issues
 # - https://github.com/solo-io/gloo-mesh-enterprise/issues/2077
 ##################################################
@@ -24,9 +24,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -54,10 +54,10 @@ spec:
     - name: ingress
   http:
   - name: frontend
-    matchers:                            # match ?cluster=cluster-1
+    matchers:                            # match ?cluster=cluster1
     - queryParameters:
       - name: cluster
-        value: cluster-1
+        value: cluster1
     forwardTo:
       destinations:
       - name: frontend
@@ -86,15 +86,15 @@ spec:
 #           domains:
 #           - "*"
 #           routes:
-#           - matchers:                    # match ?cluster=cluster-1
+#           - matchers:                    # match ?cluster=cluster1
 #             - queryParameters:
 #               - name: cluster
-#                 value: cluster-1
+#                 value: cluster1
 #             name: frontend
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
@@ -107,7 +107,7 @@ spec:
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-2
+#                   clusterName: cluster2
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/4-route-matching/4.4-method-match.yaml
+++ b/virtual-gateway/v2-api/4-route-matching/4.4-method-match.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/5-destination-routing/5.1-single-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.1-single-destination.yaml
@@ -3,7 +3,7 @@
 # Test Number: 5.1
 # API Version: 2
 # Test Description:
-#   - Route all requests to frontend application in cluster-1
+#   - Route all requests to frontend application in cluster1
 # Issues
 # - https://github.com/solo-io/gloo-mesh-enterprise/issues/2077
 ##################################################
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.10.1-add-destination-response-headers.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.10.1-add-destination-response-headers.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.10.2-remove-destination-response-header.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.10.2-remove-destination-response-header.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.11.1-add-route-request-headers.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.11.1-add-route-request-headers.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.11.2-remove-route-request-header.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.11.2-remove-route-request-header.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.12.1-add-route-response-headers.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.12.1-add-route-response-headers.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.12.2-remove-route-response-header.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.12.2-remove-route-response-header.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.2-weighted-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.2-weighted-destination.yaml
@@ -3,8 +3,8 @@
 # Test Number: 5.2
 # API Version: 2
 # Test Description:
-#   - Route 50% of requests to frontend application in cluster-1
-#   - Route 50% of requests to frontend application in cluster-2
+#   - Route 50% of requests to frontend application in cluster1
+#   - Route 50% of requests to frontend application in cluster2
 # Issues
 # - https://github.com/solo-io/gloo-mesh-enterprise/issues/2077
 ##################################################
@@ -23,9 +23,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,15 +52,15 @@
 #           - name: frontend
 #             routeAction:
 #               destinations:
-#               - weight: 50               # route 50% of traffic to frontend in cluster-2
+#               - weight: 50               # route 50% of traffic to frontend in cluster2
 #                 kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
-#               - weight: 50               # route 50% of traffic to frontend in cluster-2
+#               - weight: 50               # route 50% of traffic to frontend in cluster2
 #                 kubeService:
-#                   clusterName: cluster-2
+#                   clusterName: cluster2
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.4-multi-cluster-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.4-multi-cluster-destination.yaml
@@ -3,7 +3,7 @@
 # Test Number: 5.4
 # API Version: 2
 # Test Description:
-#   - Route all requests to frontend application in cluster-1 and cluster-2
+#   - Route all requests to frontend application in cluster1 and cluster2
 # Issues 
 #   - https://github.com/solo-io/gloo-mesh-enterprise/issues/2077
 ##################################################
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -50,14 +50,14 @@
 #           routes:
 #           - name: frontend
 #             routeAction:
-#               destinations:              # route to both cluster-1 and cluster-2 frontend
+#               destinations:              # route to both cluster1 and cluster2 frontend
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
 #               - kubeService:
-#                   clusterName: cluster-2
+#                   clusterName: cluster2
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.5-cluster-header-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.5-cluster-header-destination.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -50,16 +50,16 @@
 #           routes:
 #           - name: frontend
 #             routeAction:
-#               destinations:              # route to both cluster-1 and cluster-2 frontend
+#               destinations:              # route to both cluster1 and cluster2 frontend
 #               - clusterHeader: X-SOLO-CLUSTER  # 
 #                 kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
 #               - clusterHeader: X-SOLO-CLUSTER
 #                 kubeService:
-#                   clusterName: cluster-2
+#                   clusterName: cluster2
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.6-subset-routing.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.6-subset-routing.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -55,7 +55,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080
@@ -68,7 +68,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.7-virtual-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.7-virtual-destination.yaml
@@ -24,9 +24,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/5-destination-routing/5.8-static-destination.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.8-static-destination.yaml
@@ -24,9 +24,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/5-destination-routing/5.9.1-add-destination-request-headers.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.9.1-add-destination-request-headers.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/5-destination-routing/5.9.2-remove-destination-request-header.yaml
+++ b/virtual-gateway/v2-api/5-destination-routing/5.9.2-remove-destination-request-header.yaml
@@ -22,9 +22,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -52,7 +52,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/6-redirects/6.1-host-redirect.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.1-host-redirect.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/6-redirects/6.2-path-redirect.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.2-path-redirect.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/6-redirects/6.3-prefix-rewrite.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.3-prefix-rewrite.yaml
@@ -20,9 +20,9 @@
 #     selectors:
 #       - {}
 #   meshes:
-#     - name: istiod-istio-system-cluster-1
+#     - name: istiod-istio-system-cluster1
 #       namespace: gloo-mesh
-#     - name: istiod-istio-system-cluster-2
+#     - name: istiod-istio-system-cluster2
 #       namespace: gloo-mesh
 # ---
 # apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -55,7 +55,7 @@
 #             routeAction:
 #               destinations:
 #               - kubeService:
-#                   clusterName: cluster-1
+#                   clusterName: cluster1
 #                   name: frontend
 #                   namespace: app
 #                   port: 8080

--- a/virtual-gateway/v2-api/6-redirects/6.4-modify-response-code.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.4-modify-response-code.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/6-redirects/6.5-https-redirect.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.5-https-redirect.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/6-redirects/6.6-strip-query.yaml
+++ b/virtual-gateway/v2-api/6-redirects/6.6-strip-query.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/7-direct-response/7.1-direct-response.yaml
+++ b/virtual-gateway/v2-api/7-direct-response/7.1-direct-response.yaml
@@ -21,9 +21,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh

--- a/virtual-gateway/v2-api/8-route-delegation/8.1-namespace-selector.yaml
+++ b/virtual-gateway/v2-api/8-route-delegation/8.1-namespace-selector.yaml
@@ -3,8 +3,8 @@
 # Test Number: 8.1
 # API Version: 2
 # Test Description:
-#   - Delegate cluster-1.solo.io to cluster-1 RouteTable
-#   - Delegate cluster-2.solo.io to cluster-2 RouteTable
+#   - Delegate cluster1.solo.io to cluster1 RouteTable
+#   - Delegate cluster2.solo.io to cluster2 RouteTable
 # Issues
 # - https://github.com/solo-io/gloo-mesh-enterprise/issues/2085
 ##################################################
@@ -15,9 +15,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -40,27 +40,27 @@ metadata:
   name: admin-settings
   namespace: admin                       # workspace settings must exist in workspace namespace
 spec:
- imports:                                # import setting from cluster-1 and cluster-2 
- - name: cluster-1
- - name: cluster-2
- exportTo:                               # export to cluster-1 cluster-2 so they can use ingressgateway
- - name: cluster-1
- - name: cluster-2
+ imports:                                # import setting from cluster1 and cluster2 
+ - name: cluster1
+ - name: cluster2
+ exportTo:                               # export to cluster1 cluster2 so they can use ingressgateway
+ - name: cluster1
+ - name: cluster2
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-1                        # workspace for cluster-1 config
+  name: cluster1                        # workspace for cluster1 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-1
+   - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-1-settings
-  namespace: cluster-1                   # workspace settings must exist in workspace namespace
+  name: cluster1-settings
+  namespace: cluster1                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -68,17 +68,17 @@ spec:
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-2                        # workspace for cluster-2 config
+  name: cluster2                        # workspace for cluster2 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-2
+   - name: cluster2
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-2-settings
-  namespace: cluster-2                   # workspace settings must exist in workspace namespace
+  name: cluster2-settings
+  namespace: cluster2                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -96,47 +96,47 @@ spec:
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
-  name: cluster-1-routes
+  name: cluster1-routes
   namespace: admin
 spec:
   hosts:
-    - 'cluster-1.solo.io'
+    - 'cluster1.solo.io'
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-1-routes
-    delegate:                            # delegate cluster-1.solo.io to route tables with label cluster=cluster-1
+  - name: cluster1-routes
+    delegate:                            # delegate cluster1.solo.io to route tables with label cluster=cluster1
       routeTables:
       - selector:
-          cluster: cluster-1
+          cluster: cluster1
 ---
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
-  name: cluster-2-routes
+  name: cluster2-routes
   namespace: admin
 spec:
   hosts:
-    - 'cluster-2.solo.io'
+    - 'cluster2.solo.io'
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-2-routes
-    delegate:                            # delegate cluster-2.solo.io to route tables with label cluster=cluster-2
+  - name: cluster2-routes
+    delegate:                            # delegate cluster2.solo.io to route tables with label cluster=cluster2
       routeTables:
       - selector:
-          cluster: cluster-2
+          cluster: cluster2
 ---
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
-    cluster: cluster-1
+    cluster: cluster1
 spec:
   hosts:
-    - 'cluster-1.solo.io'
+    - 'cluster1.solo.io'
   virtualGateways:
     - name: ingress
       workspace: admin
@@ -153,12 +153,12 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-2
+  namespace: cluster2
   labels:
-    cluster: cluster-2
+    cluster: cluster2
 spec:
   hosts:
-    - 'cluster-2.solo.io'
+    - 'cluster2.solo.io'
   virtualGateways:
     - name: ingress
       workspace: admin

--- a/virtual-gateway/v2-api/8-route-delegation/8.2-label-selector.yaml
+++ b/virtual-gateway/v2-api/8-route-delegation/8.2-label-selector.yaml
@@ -3,8 +3,8 @@
 # Test Number: 8.2
 # API Version: 2
 # Test Description:
-#   - Delegate cluster-1.solo.io to cluster-1 RouteTable
-#   - Delegate cluster-2.solo.io to cluster-2 RouteTable
+#   - Delegate cluster1.solo.io to cluster1 RouteTable
+#   - Delegate cluster2.solo.io to cluster2 RouteTable
 ##################################################
 apiVersion: admin.gloo.solo.io/v2
 kind: RootTrustPolicy
@@ -13,9 +13,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -38,27 +38,27 @@ metadata:
   name: admin-settings
   namespace: admin                       # workspace settings must exist in workspace namespace
 spec:
- imports:                                # import setting from cluster-1 and cluster-2 
- - name: cluster-1
- - name: cluster-2
- exportTo:                               # export to cluster-1 cluster-2 so they can use ingressgateway
- - name: cluster-1
- - name: cluster-2
+ imports:                                # import setting from cluster1 and cluster2 
+ - name: cluster1
+ - name: cluster2
+ exportTo:                               # export to cluster1 cluster2 so they can use ingressgateway
+ - name: cluster1
+ - name: cluster2
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-1                        # workspace for cluster-1 config
+  name: cluster1                        # workspace for cluster1 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-1
+   - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-1-settings
-  namespace: cluster-1                   # workspace settings must exist in workspace namespace
+  name: cluster1-settings
+  namespace: cluster1                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -66,17 +66,17 @@ spec:
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-2                        # workspace for cluster-2 config
+  name: cluster2                        # workspace for cluster2 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-2
+   - name: cluster2
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-2-settings
-  namespace: cluster-2                   # workspace settings must exist in workspace namespace
+  name: cluster2-settings
+  namespace: cluster2                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -94,47 +94,47 @@ spec:
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
-  name: cluster-1-routes
+  name: cluster1-routes
   namespace: admin
 spec:
   hosts:
-    - 'cluster-1.solo.io'
+    - 'cluster1.solo.io'
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-1-routes
-    delegate:                            # delegate cluster-1.solo.io to route tables with label cluster=cluster-1
+  - name: cluster1-routes
+    delegate:                            # delegate cluster1.solo.io to route tables with label cluster=cluster1
       routeTables:
       - selector:
-          cluster: cluster-1
+          cluster: cluster1
 ---
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
-  name: cluster-2-routes
+  name: cluster2-routes
   namespace: admin
 spec:
   hosts:
-    - 'cluster-2.solo.io'
+    - 'cluster2.solo.io'
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-2-routes
-    delegate:                            # delegate cluster-2.solo.io to route tables with label cluster=cluster-2
+  - name: cluster2-routes
+    delegate:                            # delegate cluster2.solo.io to route tables with label cluster=cluster2
       routeTables:
       - selector:
-          cluster: cluster-2
+          cluster: cluster2
 ---
 apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
-    cluster: cluster-1
+    cluster: cluster1
 spec:
   hosts:
-    - 'cluster-1.solo.io'
+    - 'cluster1.solo.io'
   virtualGateways:
     - name: ingress
       workspace: admin
@@ -151,12 +151,12 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-2
+  namespace: cluster2
   labels:
-    cluster: cluster-2
+    cluster: cluster2
 spec:
   hosts:
-    - 'cluster-2.solo.io'
+    - 'cluster2.solo.io'
   virtualGateways:
     - name: ingress
       workspace: admin

--- a/virtual-gateway/v2-api/8-route-delegation/8.3-weighted-routes.yaml
+++ b/virtual-gateway/v2-api/8-route-delegation/8.3-weighted-routes.yaml
@@ -13,9 +13,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -38,25 +38,25 @@ metadata:
   name: admin-settings
   namespace: admin                       # workspace settings must exist in workspace namespace
 spec:
- imports:                                # import setting from cluster-1
- - name: cluster-1
- exportTo:                               # export to cluster-1 it can use ingressgateway
- - name: cluster-1
+ imports:                                # import setting from cluster1
+ - name: cluster1
+ exportTo:                               # export to cluster1 it can use ingressgateway
+ - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-1                        # workspace for cluster-1 config
+  name: cluster1                        # workspace for cluster1 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-1
+   - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-1-settings
-  namespace: cluster-1                   # workspace settings must exist in workspace namespace
+  name: cluster1-settings
+  namespace: cluster1                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -82,7 +82,7 @@ spec:
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-1-routes
+  - name: cluster1-routes
     delegate:                            # delegate frontend.solo.io to route tables with label gateway=ingress
       sortMethod: TABLE_WEIGHT
       routeTables:
@@ -93,7 +93,7 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
     gateway: ingress
 spec:
@@ -120,7 +120,7 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
     gateway: ingress
 spec:
@@ -135,7 +135,7 @@ spec:
     matchers:
     - name: frontend
       uri:
-        prefix: /frontend/cluster-2
+        prefix: /frontend/cluster2
     forwardTo:
       destinations:
       - name: frontend

--- a/virtual-gateway/v2-api/8-route-delegation/8.4-specificy-route-order.yaml
+++ b/virtual-gateway/v2-api/8-route-delegation/8.4-specificy-route-order.yaml
@@ -14,9 +14,9 @@ metadata:
   namespace: gloo-mesh
 spec:
   applyToMeshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
   config:
     rootCertificateAuthority:            # auto generate ca certificates for each istio mesh
@@ -39,25 +39,25 @@ metadata:
   name: admin-settings
   namespace: admin                       # workspace settings must exist in workspace namespace
 spec:
- imports:                                # import setting from cluster-1
- - name: cluster-1
- exportTo:                               # export to cluster-1 it can use ingressgateway
- - name: cluster-1
+ imports:                                # import setting from cluster1
+ - name: cluster1
+ exportTo:                               # export to cluster1 it can use ingressgateway
+ - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: Workspace
 metadata:
-  name: cluster-1                        # workspace for cluster-1 config
+  name: cluster1                        # workspace for cluster1 config
   namespace: gloo-mesh
 spec:
   workloadClusters:
-   - name: cluster-1
+   - name: cluster1
 ---
 apiVersion: admin.gloo.solo.io/v2
 kind: WorkspaceSettings
 metadata:
-  name: cluster-1-settings
-  namespace: cluster-1                   # workspace settings must exist in workspace namespace
+  name: cluster1-settings
+  namespace: cluster1                   # workspace settings must exist in workspace namespace
 spec:
  exportTo:                               # export to admin workspace
  - name: admin
@@ -83,7 +83,7 @@ spec:
   virtualGateways:
     - name: ingress
   http:
-  - name: cluster-1-routes
+  - name: cluster1-routes
     delegate:                            # delegate frontend.solo.io to route tables with label gateway=ingress
       sortMethod: ROUTE_SPECIFICITY
       routeTables:
@@ -94,7 +94,7 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
     gateway: ingress
 spec:
@@ -120,7 +120,7 @@ apiVersion: networking.gloo.solo.io/v2
 kind: RouteTable
 metadata:
   name: frontend
-  namespace: cluster-1
+  namespace: cluster1
   labels:
     gateway: ingress
 spec:
@@ -134,7 +134,7 @@ spec:
     matchers:
     - name: frontend
       uri:
-        prefix: /frontend/cluster-2
+        prefix: /frontend/cluster2
     forwardTo:
       destinations:
       - name: frontend

--- a/virtual-gateway/v2-api/9-traffic-shifting/9.1-weighted-destination.yaml
+++ b/virtual-gateway/v2-api/9-traffic-shifting/9.1-weighted-destination.yaml
@@ -20,9 +20,9 @@ spec:
     selectors:
       - {}
   meshes:
-    - name: istiod-istio-system-cluster-1
+    - name: istiod-istio-system-cluster1
       namespace: gloo-mesh
-    - name: istiod-istio-system-cluster-2
+    - name: istiod-istio-system-cluster2
       namespace: gloo-mesh
 ---
 apiVersion: networking.enterprise.mesh.gloo.solo.io/v1beta1
@@ -53,7 +53,7 @@ spec:
             routeAction:
               destinations:
               - kubeService:
-                  clusterName: cluster-1
+                  clusterName: cluster1
                   name: frontend
                   namespace: app
                   port: 8080


### PR DESCRIPTION
For consistency across workshops and blogs. See issue https://github.com/solo-io/gloo-mesh-enterprise/issues/2554, discussion in Slack: https://solo-io-corp.slack.com/archives/C02HR74EMQ8/p1644418811872179