### PR TITLE
Revert injection for east-west gateway

### DIFF
--- a/istio-install/1.11/eastwest-gateway.yaml
+++ b/istio-install/1.11/eastwest-gateway.yaml
@@ -98,10 +98,6 @@ spec:
 
   # Helm values overrides
   values:
-    gateways:
-      istio-eastwestgateway:
-        # Enable gateway injection
-        injectionTemplate: gateway
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:
       # Required for connecting VirtualMachines to the mesh

--- a/istio-install/1.12/eastwest-gateway.yaml
+++ b/istio-install/1.12/eastwest-gateway.yaml
@@ -98,10 +98,6 @@ spec:
 
   # Helm values overrides
   values:
-    gateways:
-      istio-eastwestgateway:
-        # Enable gateway injection
-        injectionTemplate: gateway
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:
       # Required for connecting VirtualMachines to the mesh


### PR DESCRIPTION
After testing recent changes for gateway injection, I found that injection worked for the ingress gateway, but not for the east-west gateway. Can't find anything in the Istio docs. Conferring w Ram next week, but for now removing the injection from the east-west gateway, which worked in tests.