### PR TITLE
Add east-west gateway injection

### DIFF
--- a/istio-install/1.11/eastwest-gateway.yaml
+++ b/istio-install/1.11/eastwest-gateway.yaml
@@ -98,6 +98,10 @@ spec:
 
   # Helm values overrides
   values:
+    gateways:
+      istio-ingressgateway:
+        # Enable gateway injection
+        injectionTemplate: gateway
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:
       # Required for connecting VirtualMachines to the mesh

--- a/istio-install/1.12/eastwest-gateway.yaml
+++ b/istio-install/1.12/eastwest-gateway.yaml
@@ -98,6 +98,10 @@ spec:
 
   # Helm values overrides
   values:
+    gateways:
+      istio-ingressgateway:
+        # Enable gateway injection
+        injectionTemplate: gateway
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:
       # Required for connecting VirtualMachines to the mesh


### PR DESCRIPTION
Discovered issue was that the `istio-ingressgateway` injection template is generic, and should not be changed to `istio-eastwestgateway`.