### PR TITLE
Updates for helm and istio sample installs

### DIFF
--- a/helm-install/2.0/values-data-plane.yaml
+++ b/helm-install/2.0/values-data-plane.yaml
@@ -89,6 +89,7 @@ glooMeshAgent:
   ports:
     # Port for gloo-mesh-agent service
     grpc: 9977
+    http: 9988
     # Port on which to serve internal Prometheus metrics for the agent app
     stats: 9091
   # gloo-mesh-agent pod resources

--- a/helm-install/2.0/values-mgmt-plane.yaml
+++ b/helm-install/2.0/values-mgmt-plane.yaml
@@ -18,11 +18,81 @@ leaderElection: true
 licenseKey: $GLOO_MESH_LICENSE_KEY
 # Name of the management cluster
 mgmtClusterName: $MGMT_CLUSTER
-# Disable default Prometheus instance to provide your own instance as needed
+# Enable the default Prometheus server, and deploy a production-level server to scrape
+# metrics from this server. If needed, disable this default Prometheus instance
+# to provide your own.
 prometheus:
-  enabled: false
-# Provide the URL (with port) to your own existing Prometheus instance
-prometheusUrl: "" 
+  alertmanager:
+    enabled: false
+  enabled: true
+  kubeStateMetrics:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  podSecurityPolicy:
+    enabled: false
+  pushgateway:
+    enabled: false
+  rbac:
+    create: true
+  server:
+    fullnameOverride: prometheus-server
+    persistentVolume:
+      enabled: false
+  serverFiles:
+    prometheus.yml:
+      scrape_configs:
+      - job_name: gloo-mesh
+        kubernetes_sd_configs:
+        - role: endpoints
+        relabel_configs:
+        - action: keep
+          regex: true
+          source_labels:
+          - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+        - action: keep
+          regex: gloo-mesh-mgmt-server
+          source_labels:
+          - __meta_kubernetes_pod_label_app
+        - action: keep
+          regex: gloo-mesh-mgmt-server
+          source_labels:
+          - __meta_kubernetes_endpoints_name
+        - action: replace
+          regex: (.+)
+          source_labels:
+          - __meta_kubernetes_pod_annotation_prometheus_io_path
+          target_label: __metrics_path__
+        - action: replace
+          regex: (.+):(?:\d+);(\d+)
+          replacement: ${1}:${2}
+          source_labels:
+          - __address__
+          - __meta_kubernetes_pod_annotation_prometheus_io_port
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_namespace
+          target_label: namespace
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_service_name
+          target_label: service
+        scrape_interval: 15s
+        scrape_timeout: 10s
+  serviceAccounts:
+    alertmanager:
+      create: false
+    nodeExporter:
+      create: false
+    pushgateway:
+      create: false
+    server:
+      create: true
+# Default Prometheus server address. Replace with your own as needed.
+prometheusUrl: http://prometheus-server
 verbose: false
 
 # Configuration for the gloo-mesh-mgmt-server deployment

--- a/helm-install/2.1/values-data-plane.yaml
+++ b/helm-install/2.1/values-data-plane.yaml
@@ -89,6 +89,7 @@ glooMeshAgent:
   ports:
     # Port for gloo-mesh-agent service
     grpc: 9977
+    http: 9988
     # Port on which to serve internal Prometheus metrics for the agent app
     stats: 9091
   # gloo-mesh-agent pod resources

--- a/helm-install/2.1/values-mgmt-plane.yaml
+++ b/helm-install/2.1/values-mgmt-plane.yaml
@@ -18,11 +18,81 @@ leaderElection: true
 licenseKey: $GLOO_MESH_LICENSE_KEY
 # Name of the management cluster
 mgmtClusterName: $MGMT_CLUSTER
-# Disable default Prometheus instance to provide your own instance as needed
+# Enable the default Prometheus server, and deploy a production-level server to scrape
+# metrics from this server. If needed, disable this default Prometheus instance
+# to provide your own.
 prometheus:
-  enabled: false
-# Provide the URL (with port) to your own existing Prometheus instance
-prometheusUrl: "" 
+  alertmanager:
+    enabled: false
+  enabled: true
+  kubeStateMetrics:
+    enabled: false
+  nodeExporter:
+    enabled: false
+  podSecurityPolicy:
+    enabled: false
+  pushgateway:
+    enabled: false
+  rbac:
+    create: true
+  server:
+    fullnameOverride: prometheus-server
+    persistentVolume:
+      enabled: false
+  serverFiles:
+    prometheus.yml:
+      scrape_configs:
+      - job_name: gloo-mesh
+        kubernetes_sd_configs:
+        - role: endpoints
+        relabel_configs:
+        - action: keep
+          regex: true
+          source_labels:
+          - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+        - action: keep
+          regex: gloo-mesh-mgmt-server
+          source_labels:
+          - __meta_kubernetes_pod_label_app
+        - action: keep
+          regex: gloo-mesh-mgmt-server
+          source_labels:
+          - __meta_kubernetes_endpoints_name
+        - action: replace
+          regex: (.+)
+          source_labels:
+          - __meta_kubernetes_pod_annotation_prometheus_io_path
+          target_label: __metrics_path__
+        - action: replace
+          regex: (.+):(?:\d+);(\d+)
+          replacement: ${1}:${2}
+          source_labels:
+          - __address__
+          - __meta_kubernetes_pod_annotation_prometheus_io_port
+          target_label: __address__
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_namespace
+          target_label: namespace
+        - action: replace
+          source_labels:
+          - __meta_kubernetes_service_name
+          target_label: service
+        scrape_interval: 15s
+        scrape_timeout: 10s
+  serviceAccounts:
+    alertmanager:
+      create: false
+    nodeExporter:
+      create: false
+    pushgateway:
+      create: false
+    server:
+      create: true
+# Default Prometheus server address. Replace with your own as needed.
+prometheusUrl: http://prometheus-server
 verbose: false
 
 # Configuration for the gloo-mesh-mgmt-server deployment

--- a/istio-install/1.12/eastwest-gateway.yaml
+++ b/istio-install/1.12/eastwest-gateway.yaml
@@ -62,20 +62,20 @@ spec:
             #type: LoadBalancer
             # Default ports
             ports:
-              # Health check port. For AWS ELBs, this port must be listed first.
-              - name: status-port
-                port: 15021
+              # Port for health checks on path /healthz/ready. For AWS ELBs, this port must be listed first.
+              - port: 15021
                 targetPort: 15021
+                name: status-port
               # Port for multicluster mTLS passthrough; required for Gloo Mesh east/west routing
               - port: 15443
                 targetPort: 15443
                 # Gloo Mesh looks for this default name 'tls' on a gateway
                 name: tls
               # Port required for VM onboarding
-              - port: 15012
-                targetPort: 15012
+              #- port: 15012
+                #targetPort: 15012
                 # Required for VM onboarding discovery address
-                name: tls-istiod
+                #name: tls-istiod
           overlays:
             - apiVersion: apps/v1
               kind: Deployment

--- a/istio-install/1.12/ingress-gateway.yaml
+++ b/istio-install/1.12/ingress-gateway.yaml
@@ -55,7 +55,7 @@ spec:
           service:
             # Default ports
             ports:
-              # Health check port. For AWS ELBs, this port must be listed first.
+              # Port for health checks on path /healthz/ready. For AWS ELBs, this port must be listed first.
               - name: status-port
                 port: 15021
                 targetPort: 15021

--- a/istio-install/1.13/eastwest-gateway.yaml
+++ b/istio-install/1.13/eastwest-gateway.yaml
@@ -62,7 +62,7 @@ spec:
             #type: LoadBalancer
             # Default ports
             ports:
-              # Health check port. For AWS ELBs, this port must be listed first.
+              # Port for health checks on path /healthz/ready. For AWS ELBs, this port must be listed first.
               - port: 15021
                 targetPort: 15021
                 name: status-port
@@ -72,10 +72,10 @@ spec:
                 # Gloo Mesh looks for this default name 'tls' on a gateway
                 name: tls
               # Port required for VM onboarding
-              - port: 15012
-                targetPort: 15012
+              #- port: 15012
+                #targetPort: 15012
                 # Required for VM onboarding discovery address
-                name: tls-istiod
+                #name: tls-istiod
           overlays:
             - apiVersion: apps/v1
               kind: Deployment

--- a/istio-install/1.13/ingress-gateway.yaml
+++ b/istio-install/1.13/ingress-gateway.yaml
@@ -55,7 +55,7 @@ spec:
           service:
             # Default ports
             ports:
-              # Health check port. For AWS ELBs, this port must be listed first.
+              # Port for health checks on path /healthz/ready. For AWS ELBs, this port must be listed first.
               - name: status-port
                 port: 15021
                 targetPort: 15021


### PR DESCRIPTION
Helm for GME install: update guidance on production-level prometheus. Include default prometheus setu in our production-level sample.

Istio operators: Update ports descriptions and whether vm ports are required.