### PR TITLE
disable PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES

### DIFF
--- a/getting-started/2.0/demo-istio-openshift.yaml
+++ b/getting-started/2.0/demo-istio-openshift.yaml
@@ -75,7 +75,11 @@ spec:
     pilot:
       k8s:
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
   values:

--- a/getting-started/2.0/demo-istio-openshift.yaml
+++ b/getting-started/2.0/demo-istio-openshift.yaml
@@ -76,7 +76,7 @@ spec:
       k8s:
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/getting-started/2.0/demo-istio.yaml
+++ b/getting-started/2.0/demo-istio.yaml
@@ -95,12 +95,13 @@ spec:
     pilot:
       k8s:
         env:
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
-          # Disable selecting workload entries for local service routing. Required for proper Gloo Mesh VirtualDestinaton functionality
-          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
-            value: "false"
   values:
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:

--- a/getting-started/2.0/demo-istio.yaml
+++ b/getting-started/2.0/demo-istio.yaml
@@ -96,7 +96,7 @@ spec:
       k8s:
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/getting-started/2.0/demo-istio.yaml
+++ b/getting-started/2.0/demo-istio.yaml
@@ -95,9 +95,12 @@ spec:
     pilot:
       k8s:
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
+          # Disable selecting workload entries for local service routing. Required for proper Gloo Mesh VirtualDestinaton functionality
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
   values:
     # https://istio.io/v1.5/docs/reference/config/installation-options/#global-options
     global:

--- a/getting-started/2.1/demo-istio-openshift.yaml
+++ b/getting-started/2.1/demo-istio-openshift.yaml
@@ -75,7 +75,11 @@ spec:
     pilot:
       k8s:
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
   values:

--- a/getting-started/2.1/demo-istio-openshift.yaml
+++ b/getting-started/2.1/demo-istio-openshift.yaml
@@ -76,7 +76,7 @@ spec:
       k8s:
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/getting-started/2.1/demo-istio.yaml
+++ b/getting-started/2.1/demo-istio.yaml
@@ -96,7 +96,7 @@ spec:
       k8s:
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/getting-started/2.1/demo-istio.yaml
+++ b/getting-started/2.1/demo-istio.yaml
@@ -95,7 +95,11 @@ spec:
     pilot:
       k8s:
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
   values:

--- a/istio-install/1.12/istiod-kubernetes.yaml
+++ b/istio-install/1.12/istiod-kubernetes.yaml
@@ -82,7 +82,11 @@ spec:
                 targetAverageUtilization: 60
               type: Resource
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
 

--- a/istio-install/1.12/istiod-kubernetes.yaml
+++ b/istio-install/1.12/istiod-kubernetes.yaml
@@ -83,7 +83,7 @@ spec:
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/istio-install/1.12/istiod-openshift.yaml
+++ b/istio-install/1.12/istiod-openshift.yaml
@@ -85,7 +85,11 @@ spec:
                 targetAverageUtilization: 60
               type: Resource
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
     # Openshift requires the Istio CNI feature to be enabled

--- a/istio-install/1.12/istiod-openshift.yaml
+++ b/istio-install/1.12/istiod-openshift.yaml
@@ -86,7 +86,7 @@ spec:
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/istio-install/1.13/istiod-kubernetes.yaml
+++ b/istio-install/1.13/istiod-kubernetes.yaml
@@ -82,9 +82,12 @@ spec:
                 targetAverageUtilization: 60
               type: Resource
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
+          # Disable selecting workload entries for local service routing. Required for proper Gloo Mesh VirtualDestinaton functionality
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
 
     # Istio Gateway feature
     # Disable gateways deployments, which are deployed in separate IstioOperator configurations

--- a/istio-install/1.13/istiod-kubernetes.yaml
+++ b/istio-install/1.13/istiod-kubernetes.yaml
@@ -83,7 +83,7 @@ spec:
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)

--- a/istio-install/1.13/istiod-kubernetes.yaml
+++ b/istio-install/1.13/istiod-kubernetes.yaml
@@ -82,12 +82,13 @@ spec:
                 targetAverageUtilization: 60
               type: Resource
         env:
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
-          # Disable selecting workload entries for local service routing. Required for proper Gloo Mesh VirtualDestinaton functionality
-          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
-            value: "false"
 
     # Istio Gateway feature
     # Disable gateways deployments, which are deployed in separate IstioOperator configurations

--- a/istio-install/1.13/istiod-openshift.yaml
+++ b/istio-install/1.13/istiod-openshift.yaml
@@ -85,7 +85,11 @@ spec:
                 targetAverageUtilization: 60
               type: Resource
         env:
-         # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
+          # Disable selecting workload entries for local service routing.
+          # Required for Gloo Mesh VirtualDestinaton functionality.
+          - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
+            value: "false"
+          # Allow multiple trust domains (Required for Gloo Mesh east/west routing)
           - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
             value: "true"
     # Openshift requires the Istio CNI feature to be enabled

--- a/istio-install/1.13/istiod-openshift.yaml
+++ b/istio-install/1.13/istiod-openshift.yaml
@@ -86,7 +86,7 @@ spec:
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.
-          # Required for Gloo Mesh VirtualDestinaton functionality.
+          # Required for Gloo Mesh VirtualDestination functionality.
           - name: PILOT_ENABLE_K8S_SELECT_WORKLOAD_ENTRIES
             value: "false"
           # Allow multiple trust domains (Required for Gloo Mesh east/west routing)


### PR DESCRIPTION
This IstioOperator yaml is used in our documentation for Istio installation. 

Without disabling this, `currencyservice.backend-apis.svc.cluster.local` will select both local and remote endpoints (from WorkloadEntries).

```
~ 🏎  $ istioctl pc endpoints frontend-848b87869-cfpp8.web-ui | grep currencyservice.backend-apis.svc.cluster.local
10.16.1.53:7000                  HEALTHY     OK                outbound|7000||currencyservice.backend-apis.svc.cluster.local
34.82.32.121:15443               HEALTHY     OK                outbound|7000||currencyservice.backend-apis.svc.cluster.local
```