### PR TITLE
Rm gloo_mesh_cluster_name

### DIFF
--- a/gloo-gateway/istio-install/eastwest-gateway.yaml
+++ b/gloo-gateway/istio-install/eastwest-gateway.yaml
@@ -115,6 +115,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-gateway/istio-install/ingress-gateway.yaml
+++ b/gloo-gateway/istio-install/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-gateway/istio-install/istiod-kubernetes.yaml
+++ b/gloo-gateway/istio-install/istiod-kubernetes.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -108,7 +105,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-gateway/istio-install/istiod-openshift.yaml
+++ b/gloo-gateway/istio-install/istiod-openshift.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -135,7 +132,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.11/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.11/eastwest-gateway.yaml
@@ -108,6 +108,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.11/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.11/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.11/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.11/istiod-kubernetes.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh Dashboard
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -103,7 +104,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.11/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.11/istiod-openshift.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh Dashboard
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -130,7 +131,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.12/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.12/eastwest-gateway.yaml
@@ -115,6 +115,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.12/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.12/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.12/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.12/istiod-kubernetes.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -108,7 +109,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.12/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.12/istiod-openshift.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -135,7 +136,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.13/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.13/eastwest-gateway.yaml
@@ -115,6 +115,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.13/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.13/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.13/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.13/istiod-kubernetes.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -108,7 +109,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.13/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.13/istiod-openshift.yaml
@@ -39,7 +39,8 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
+        # Gloo Mesh 2.0 and earlier only:
+        # Gloo Mesh metrics aggregation for Gloo Mesh Dashboard
         # Must match the trustDomain
         GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
@@ -135,7 +136,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.14/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.14/eastwest-gateway.yaml
@@ -115,6 +115,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.14/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.14/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -108,7 +105,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -135,7 +132,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.15/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.15/eastwest-gateway.yaml
@@ -115,6 +115,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.15/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.15/ingress-gateway.yaml
@@ -106,6 +106,6 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -108,7 +105,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings

--- a/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
@@ -39,9 +39,6 @@ spec:
         ISTIO_META_DNS_CAPTURE: "true"
         # Enable automatic address allocation (for proxy-dns)
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-        # Used for Gloo Mesh metrics aggregation; required for Gloo Mesh UI
-        # Must match the trustDomain
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:
@@ -135,7 +132,7 @@ spec:
       # Required for connecting VirtualMachines to the mesh
       network: $CLUSTER_NAME
       # Required for annotating Istio metrics with the cluster name.
-      # Must match the trustDomain and GLOO_MESH_CLUSTER_NAME
+      # Must match the trustDomain
       multiCluster:
         clusterName: $CLUSTER_NAME
       # Sidecar resource settings


### PR DESCRIPTION
Remove gloo_mesh_cluster_name from istio installs in Gloo 2.1+, which is no longer required for metrics aggregation. 
- Removed from all Gateway sample installs (Gloo Gateway is 2.1+ only)
- Removed from Mesh Istio 1.14 and 1.15 as these are only supported on 2.1+. 
- For Mesh Istio 1.11-1.13 (which are supported for 2.0 and earlier as well as 2.1 and later), added a note that the field is only required in Mesh 2.0 and earlier.