### PR TITLE
Doc fixes

### DIFF
--- a/gloo-gateway/istio-install/eastwest-gateway.yaml
+++ b/gloo-gateway/istio-install/eastwest-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-gateway/istio-install/ingress-gateway.yaml
+++ b/gloo-gateway/istio-install/ingress-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-gateway/istio-install/istiod-kubernetes.yaml
+++ b/gloo-gateway/istio-install/istiod-kubernetes.yaml
@@ -74,7 +74,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-gateway/istio-install/istiod-openshift.yaml
+++ b/gloo-gateway/istio-install/istiod-openshift.yaml
@@ -77,7 +77,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.12/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.12/eastwest-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.14/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.14/eastwest-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.14/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.14/ingress-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
@@ -76,7 +76,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
@@ -79,7 +79,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.15/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.15/eastwest-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.15/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.15/ingress-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
@@ -76,7 +76,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
@@ -79,7 +79,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.16/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/1.16/eastwest-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.16/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/1.16/ingress-gateway.yaml
@@ -34,7 +34,6 @@ spec:
             metrics:
               - resource:
                   name: cpu
-                  targetAverageUtilization: 60
                 type: Resource
             minReplicas: 2
             scaleTargetRef:

--- a/gloo-mesh/istio-install/1.16/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.16/istiod-kubernetes.yaml
@@ -74,7 +74,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.

--- a/gloo-mesh/istio-install/1.16/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.16/istiod-openshift.yaml
@@ -77,7 +77,6 @@ spec:
           metrics:
             - resource:
                 name: cpu
-                targetAverageUtilization: 60
               type: Resource
         env:
           # Disable selecting workload entries for local service routing.


### PR DESCRIPTION
Remove deprecated `targetAverageUtilization` setting in Istio 1.14+
* See Slack thread: https://solo-io-corp.slack.com/archives/CHAC8587L/p1678204749342859?thread_ts=1678199784.305919&cid=CHAC8587L