### PR TITLE
add topology key to manual istio files

### DIFF
--- a/gloo-mesh/istio-install/manual-helm/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/manual-helm/eastwest-gateway.yaml
@@ -76,3 +76,4 @@ affinity:
           operator: In
           values:
           - istio-eastwestgateway-${REVISION}
+      topologyKey: kubernetes.io/hostname

--- a/gloo-mesh/istio-install/manual-helm/ingress-gateway.yaml
+++ b/gloo-mesh/istio-install/manual-helm/ingress-gateway.yaml
@@ -72,3 +72,4 @@ affinity:
           operator: In
           values:
           - istio-ingressgateway-${REVISION}
+      topologyKey: kubernetes.io/hostname

--- a/gloo-mesh/istio-install/manual-helm/istiod.yaml
+++ b/gloo-mesh/istio-install/manual-helm/istiod.yaml
@@ -121,3 +121,4 @@ pilot:
             operator: In
             values:
             - istiod-${REVISION}
+        topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Missing `topologyKey: kubernetes.io/hostname` from pod anti affinity in Helm istio files 