### PR TITLE
Change HTTP Version from HTTP/1.0 to HTTP/1.1 for helloworld readiness check

### DIFF
--- a/policy-demo/helloworld.yaml
+++ b/policy-demo/helloworld.yaml
@@ -60,7 +60,7 @@ spec:
               - |
                 if [ $FAIL_READINESS = "True" ]; then exit 1;
                 elif [ $DISABLE_CONTAINER = "True" ]; then exit 0;
-                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.0 200"; fi
+                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.1 200"; fi
       - name: curl
         image: curlimages/curl:7.83.1
         imagePullPolicy: IfNotPresent
@@ -120,7 +120,7 @@ spec:
               - |
                 if [ $FAIL_READINESS = "True" ]; then exit 1;
                 elif [ $DISABLE_CONTAINER = "True" ]; then exit 0;
-                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.0 200"; fi
+                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.1 200"; fi
       - name: curl
         image: curlimages/curl:7.83.1
         imagePullPolicy: IfNotPresent
@@ -180,7 +180,7 @@ spec:
               - |
                 if [ $FAIL_READINESS = "True" ]; then exit 1;
                 elif [ $DISABLE_CONTAINER = "True" ]; then exit 0;
-                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.0 200"; fi
+                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.1 200"; fi
       - name: curl
         image: curlimages/curl:7.83.1
         imagePullPolicy: IfNotPresent
@@ -240,7 +240,7 @@ spec:
               - |
                 if [ $FAIL_READINESS = "True" ]; then exit 1;
                 elif [ $DISABLE_CONTAINER = "True" ]; then exit 0;
-                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.0 200"; fi
+                else curl http://localhost:5000/health -I -X GET | grep "HTTP/1.1 200"; fi
       - name: curl
         image: curlimages/curl:7.83.1
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Hello world app has been updated to respond only to HTTP/1.1 for readiness probes. This PR is to reflect that change here so that the hello world app continues to function fully.