### PR TITLE
Update Istio files for legacy metrics settings

### DIFF
--- a/gloo-gateway/istio-install/istiod-kubernetes.yaml
+++ b/gloo-gateway/istio-install/istiod-kubernetes.yaml
@@ -25,19 +25,17 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:
         # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
         # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: ${CLUSTER_NAME}
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:

--- a/gloo-gateway/istio-install/istiod-openshift.yaml
+++ b/gloo-gateway/istio-install/istiod-openshift.yaml
@@ -25,19 +25,17 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:
         # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
         # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:

--- a/gloo-gateway/istio-install/manual-helm/istiod.yaml
+++ b/gloo-gateway/istio-install/manual-helm/istiod.yaml
@@ -32,12 +32,12 @@ global:
     # Wait for the sidecar to be injected into the istio-proxy container
     # and block the start of the other containers until the proxy is ready.
     holdApplicationUntilProxyStarts: false
-    # Required for connecting VirtualMachines to the mesh.
-    network: $CLUSTER_NAME
-    # Required for annotating Istio metrics with the cluster name.
-    # Must match the trustDomain.
-    multiCluster:
-      clusterName: $CLUSTER_NAME
+  # Required for connecting VirtualMachines to the mesh.
+  network: $CLUSTER_NAME
+  # Required for annotating Istio metrics with the cluster name.
+  # Must match the trustDomain.
+  multiCluster:
+    clusterName: $CLUSTER_NAME
 
 # Mesh configuration options
 meshConfig:
@@ -56,10 +56,11 @@ meshConfig:
   defaultConfig:
     # Wait for the istio-proxy to start before starting application pods
     holdApplicationUntilProxyStarts: true
-    # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI.
+    # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+    # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
     envoyMetricsService:
       address: gloo-mesh-agent.gloo-mesh:9977
-    # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging.
+    # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
     envoyAccessLogService:
       address: gloo-mesh-agent.gloo-mesh:9977
     # The amount of time allowed for connections to complete upon proxy shutdown.
@@ -75,9 +76,6 @@ meshConfig:
       # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
       # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
       ISTIO_META_DNS_CAPTURE: "true"
-      # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-      # Must match the trustDomain.
-      GLOO_MESH_CLUSTER_NAME: ${CLUSTER_NAME}
 
 pilot:
   autoscaleEnabled: true

--- a/gloo-mesh/istio-install/1.12/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.12/istiod-kubernetes.yaml
@@ -25,11 +25,12 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977

--- a/gloo-mesh/istio-install/1.12/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.12/istiod-openshift.yaml
@@ -25,11 +25,12 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977

--- a/gloo-mesh/istio-install/1.13/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.13/istiod-kubernetes.yaml
@@ -25,11 +25,12 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977

--- a/gloo-mesh/istio-install/1.13/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.13/istiod-openshift.yaml
@@ -25,11 +25,12 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977

--- a/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-kubernetes.yaml
@@ -25,12 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.14/istiod-openshift.yaml
@@ -25,12 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-kubernetes.yaml
@@ -25,12 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.15/istiod-openshift.yaml
@@ -25,12 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      # For Gloo Mesh Enterprise version 1.2, change to enterprise-agent.gloo-mesh:9977
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.16/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.16/istiod-kubernetes.yaml
@@ -25,10 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.16/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.16/istiod-openshift.yaml
@@ -25,10 +25,11 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+      # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
       envoyMetricsService:
         address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
+      # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
       envoyAccessLogService:
         address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:

--- a/gloo-mesh/istio-install/1.17/istiod-kubernetes.yaml
+++ b/gloo-mesh/istio-install/1.17/istiod-kubernetes.yaml
@@ -25,19 +25,10 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      envoyMetricsService:
-        address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      envoyAccessLogService:
-        address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:
         # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
         # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/1.17/istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/1.17/istiod-openshift.yaml
@@ -25,19 +25,10 @@ spec:
     defaultConfig:
       # Wait for the istio-proxy to start before starting application pods
       holdApplicationUntilProxyStarts: true
-      # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI
-      envoyMetricsService:
-        address: gloo-mesh-agent.gloo-mesh:9977
-      # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging
-      envoyAccessLogService:
-        address: gloo-mesh-agent.gloo-mesh:9977
       proxyMetadata:
         # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
         # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
 
     # Set the default behavior of the sidecar for handling outbound traffic from the application
     outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/gm-egress-gateway.yaml
+++ b/gloo-mesh/istio-install/gm-managed/gm-egress-gateway.yaml
@@ -28,16 +28,10 @@ spec:
             # enable accesslogs
           accessLogFile: /dev/stdout
           defaultConfig:
-            # enable Gloo Mesh accesslog service (equired for Gloo Mesh Access Log forwarding)
-            envoyAccessLogService:
-              address: gloo-mesh-agent.gloo-mesh:9977
             proxyMetadata:
               # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
               # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
               ISTIO_META_DNS_CAPTURE: "true"
-              # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-              # Must match the trustDomain.
-              GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
         components:
           egressGateways:
           # Enable the egress gateway

--- a/gloo-mesh/istio-install/gm-managed/gm-istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/gm-managed/gm-istiod-openshift.yaml
@@ -35,16 +35,17 @@ spec:
         defaultConfig:
           # Wait for the istio-proxy to start before starting application pods
           holdApplicationUntilProxyStarts: true
-          # Enable Gloo accesslog service. Required for Gloo Access Logging
+          # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+          # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
+          envoyMetricsService:
+            address: gloo-mesh-agent.gloo-mesh:9977
+          # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
           envoyAccessLogService:
             address: gloo-mesh-agent.gloo-mesh:9977
           proxyMetadata:
             # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
             # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
             ISTIO_META_DNS_CAPTURE: "true"
-            # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-            # Must match the trustDomain.
-            GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
         # Set the default behavior of the sidecar for handling outbound traffic
         # from the application
         outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/gm-istiod.yaml
+++ b/gloo-mesh/istio-install/gm-managed/gm-istiod.yaml
@@ -35,16 +35,17 @@ spec:
         defaultConfig:
           # Wait for the istio-proxy to start before starting application pods
           holdApplicationUntilProxyStarts: true
-          # Enable Gloo accesslog service. Required for Gloo Access Logging
+          # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+          # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
+          envoyMetricsService:
+            address: gloo-mesh-agent.gloo-mesh:9977
+          # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
           envoyAccessLogService:
             address: gloo-mesh-agent.gloo-mesh:9977
           proxyMetadata:
             # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
             # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
             ISTIO_META_DNS_CAPTURE: "true"
-            # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-            # Must match the trustDomain.
-            GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
         # Set the default behavior of the sidecar for handling outbound traffic
         # from the application
         outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/single-cluster/gm-istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/gm-managed/single-cluster/gm-istiod-openshift.yaml
@@ -33,19 +33,17 @@ spec:
           defaultConfig:
             # Wait for the istio-proxy to start before starting application pods
             holdApplicationUntilProxyStarts: true
-            # Enable Gloo metrics service. Required for Gloo UI
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+            # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
             envoyMetricsService:
               address: gloo-mesh-agent.gloo-mesh:9977
-            # Enable Gloo accesslog service. Required for Gloo Access Logging
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
             envoyAccessLogService:
               address: gloo-mesh-agent.gloo-mesh:9977
             proxyMetadata:
               # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
               # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
               ISTIO_META_DNS_CAPTURE: "true"
-              # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-              # Must match the trustDomain.
-              GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
           # Set the default behavior of the sidecar for handling outbound traffic
           # from the application
           outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/single-cluster/gm-istiod.yaml
+++ b/gloo-mesh/istio-install/gm-managed/single-cluster/gm-istiod.yaml
@@ -33,19 +33,17 @@ spec:
           defaultConfig:
             # Wait for the istio-proxy to start before starting application pods
             holdApplicationUntilProxyStarts: true
-            # Enable Gloo metrics service. Required for Gloo UI
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+            # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
             envoyMetricsService:
               address: gloo-mesh-agent.gloo-mesh:9977
-            # Enable Gloo accesslog service. Required for Gloo Access Logging
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
             envoyAccessLogService:
               address: gloo-mesh-agent.gloo-mesh:9977
             proxyMetadata:
               # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
               # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
               ISTIO_META_DNS_CAPTURE: "true"
-              # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-              # Must match the trustDomain.
-              GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
           # Set the default behavior of the sidecar for handling outbound traffic
           # from the application
           outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/takeover/gm-istiod-openshift.yaml
+++ b/gloo-mesh/istio-install/gm-managed/takeover/gm-istiod-openshift.yaml
@@ -36,19 +36,17 @@ spec:
           defaultConfig:
             # Wait for the istio-proxy to start before starting application pods
             holdApplicationUntilProxyStarts: true
-            # Enable Gloo metrics service. Required for Gloo UI
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+            # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
             envoyMetricsService:
               address: gloo-mesh-agent.gloo-mesh:9977
-            # Enable Gloo accesslog service. Required for Gloo Access Logging
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
             envoyAccessLogService:
               address: gloo-mesh-agent.gloo-mesh:9977
             proxyMetadata:
               # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
               # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
               ISTIO_META_DNS_CAPTURE: "true"
-              # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-              # Must match the trustDomain.
-              GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
           # Set the default behavior of the sidecar for handling outbound traffic
           # from the application
           outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/gm-managed/takeover/gm-istiod.yaml
+++ b/gloo-mesh/istio-install/gm-managed/takeover/gm-istiod.yaml
@@ -36,19 +36,17 @@ spec:
           defaultConfig:
             # Wait for the istio-proxy to start before starting application pods
             holdApplicationUntilProxyStarts: true
-            # Enable Gloo metrics service. Required for Gloo UI
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+            # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
             envoyMetricsService:
               address: gloo-mesh-agent.gloo-mesh:9977
-            # Enable Gloo accesslog service. Required for Gloo Access Logging
+            # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
             envoyAccessLogService:
               address: gloo-mesh-agent.gloo-mesh:9977
             proxyMetadata:
               # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
               # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
               ISTIO_META_DNS_CAPTURE: "true"
-              # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-              # Must match the trustDomain.
-              GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME
           # Set the default behavior of the sidecar for handling outbound traffic
           # from the application
           outboundTrafficPolicy:

--- a/gloo-mesh/istio-install/manual-helm/istiod.yaml
+++ b/gloo-mesh/istio-install/manual-helm/istiod.yaml
@@ -32,12 +32,12 @@ global:
     # Wait for the sidecar to be injected into the istio-proxy container
     # and block the start of the other containers until the proxy is ready.
     holdApplicationUntilProxyStarts: false
-    # Required for connecting VirtualMachines to the mesh.
-    network: $CLUSTER_NAME
-    # Required for annotating Istio metrics with the cluster name.
-    # Must match the trustDomain.
-    multiCluster:
-      clusterName: $CLUSTER_NAME
+  # Required for connecting VirtualMachines to the mesh.
+  network: $CLUSTER_NAME
+  # Required for annotating Istio metrics with the cluster name.
+  # Must match the trustDomain.
+  multiCluster:
+    clusterName: $CLUSTER_NAME
 
 # Mesh configuration options
 meshConfig:
@@ -56,10 +56,11 @@ meshConfig:
   defaultConfig:
     # Wait for the istio-proxy to start before starting application pods
     holdApplicationUntilProxyStarts: true
-    # Enable Gloo Mesh metrics service. Required for Gloo Mesh UI.
+    # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier:
+    # Enable the legacy Gloo metrics service. For more info, see https://docs.solo.io/gloo-mesh/latest/observability/pipeline/.
     envoyMetricsService:
       address: gloo-mesh-agent.gloo-mesh:9977
-    # Enable Gloo Mesh accesslog service. Required for Gloo Mesh Access Logging.
+    # Legacy metrics pipeline only, in Gloo Istio 1.17 and earlier: Enable Gloo access logging.
     envoyAccessLogService:
       address: gloo-mesh-agent.gloo-mesh:9977
     # The amount of time allowed for connections to complete upon proxy shutdown.
@@ -75,9 +76,6 @@ meshConfig:
       # For known hosts, enable the Istio agent to handle DNS requests for any custom ServiceEntry, such as non-Kubernetes services.
       # Unknown hosts are automatically resolved using upstream DNS servers in resolv.conf (for proxy-dns)
       ISTIO_META_DNS_CAPTURE: "true"
-      # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-      # Must match the trustDomain.
-      GLOO_MESH_CLUSTER_NAME: ${CLUSTER_NAME}
 
 pilot:
   autoscaleEnabled: true

--- a/gloo-mesh/istio-install/vm-agent/aws.yaml
+++ b/gloo-mesh/istio-install/vm-agent/aws.yaml
@@ -162,6 +162,3 @@ spec:
         # Unknown hosts are automatically resolved using upstream DNS servers
         # in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME

--- a/gloo-mesh/istio-install/vm-agent/gcp.yaml
+++ b/gloo-mesh/istio-install/vm-agent/gcp.yaml
@@ -155,6 +155,3 @@ spec:
         # Unknown hosts are automatically resolved using upstream DNS servers
         # in resolv.conf (for proxy-dns)
         ISTIO_META_DNS_CAPTURE: "true"
-        # Used for Gloo Mesh metrics aggregation. Required for Gloo Mesh UI.
-        # Must match the trustDomain.
-        GLOO_MESH_CLUSTER_NAME: $CLUSTER_NAME


### PR DESCRIPTION
- Rm `GLOO_MESH_CLUSTER_NAME` which is no longer used at all
- Rm `envoyMetricsService` and `envoyAccessLogService` fields for legacy metrics pipeline from any 1.17+ files, and mark it legacy (but leave it in) for any other files just in case
- Fix the global.multicluster setting's tabbing in the manual-helm istio files.