### PR TITLE
Istio egress meshConfig

### DIFF
--- a/gloo-mesh-core/istio-install/managed/multi/egress-gateway.yaml
+++ b/gloo-mesh-core/istio-install/managed/multi/egress-gateway.yaml
@@ -16,6 +16,19 @@ spec:
       # The revision for this installation, such as 1-18-3
     gatewayRevision: $REVISION
     istioOperatorSpec:
+      meshConfig:
+        # Allow outbound traffic to any external endpoint
+        outboundTrafficPolicy:
+          mode: ALLOW_ANY
+          # Enable access logs
+        accessLogFile: /dev/stdout
+        defaultConfig:
+          proxyMetadata:
+            # For known hosts, enable the Istio agent to handle DNS requests
+            # for any custom ServiceEntry, such as non-Kubernetes services.
+            # Unknown hosts are automatically resolved using upstream DNS
+            # servers in resolv.conf (for proxy-dns)
+            ISTIO_META_DNS_CAPTURE: "true"
       components:
         egressGateways:
           # Enable the default egress gateway
@@ -45,19 +58,6 @@ spec:
             # Required to ensure Gateways can select this workload
             istio: egressgateway
             traffic: egress
-          meshConfig:
-            # Allow outbound traffic to any external endpoint
-            outboundTrafficPolicy:
-              mode: ALLOW_ANY
-              # Enable access logs
-            accessLogFile: /dev/stdout
-            defaultConfig:
-              proxyMetadata:
-                # For known hosts, enable the Istio agent to handle DNS requests
-                # for any custom ServiceEntry, such as non-Kubernetes services.
-                # Unknown hosts are automatically resolved using upstream DNS
-                # servers in resolv.conf (for proxy-dns)
-                ISTIO_META_DNS_CAPTURE: "true"
           name: istio-egressgateway
           # Deployed to gloo-mesh-gateways by default
           namespace: gloo-mesh-gateways

--- a/gloo-mesh-core/istio-install/managed/single/egress-gateway.yaml
+++ b/gloo-mesh-core/istio-install/managed/single/egress-gateway.yaml
@@ -13,6 +13,19 @@ spec:
       # The revision for this installation, such as 1-18-3
     gatewayRevision: $REVISION
     istioOperatorSpec:
+      meshConfig:
+        # Allow outbound traffic to any external endpoint
+        outboundTrafficPolicy:
+          mode: ALLOW_ANY
+          # Enable access logs
+        accessLogFile: /dev/stdout
+        defaultConfig:
+          proxyMetadata:
+            # For known hosts, enable the Istio agent to handle DNS requests
+            # for any custom ServiceEntry, such as non-Kubernetes services.
+            # Unknown hosts are automatically resolved using upstream DNS
+            # servers in resolv.conf (for proxy-dns)
+            ISTIO_META_DNS_CAPTURE: "true"
       components:
         egressGateways:
           # Enable the default egress gateway
@@ -42,19 +55,6 @@ spec:
             # Required to ensure Gateways can select this workload
             istio: egressgateway
             traffic: egress
-          meshConfig:
-            # Allow outbound traffic to any external endpoint
-            outboundTrafficPolicy:
-              mode: ALLOW_ANY
-              # Enable access logs
-            accessLogFile: /dev/stdout
-            defaultConfig:
-              proxyMetadata:
-                # For known hosts, enable the Istio agent to handle DNS requests
-                # for any custom ServiceEntry, such as non-Kubernetes services.
-                # Unknown hosts are automatically resolved using upstream DNS
-                # servers in resolv.conf (for proxy-dns)
-                ISTIO_META_DNS_CAPTURE: "true"
           name: istio-egressgateway
           # Deployed to gloo-mesh-gateways by default
           namespace: gloo-mesh-gateways


### PR DESCRIPTION
Got an error the initial way:

```
Error from server (BadRequest): error when creating "egress-gateway-values.yaml": GatewayLifecycleManager in version "v2" cannot be handled as a GatewayLifecycleManager: strict decoding error: unknown field "spec.installations[0].istioOperatorSpec.components.egressGateways[0].meshConfig"
```

I noticed the indentation looked off from other egress config, like here: https://github.com/solo-io/gloo-mesh-use-cases/blob/main/gloo-mesh/istio-install/gm-managed/gm-egress-gateway.yaml#L25