### PR TITLE
Increased retry delay to 30s

### DIFF
--- a/gloo-gateway/portal/pets-api-v1.yaml
+++ b/gloo-gateway/portal/pets-api-v1.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     gloo.solo.io/scrape-openapi-source: /swagger.json
-    gloo.solo.io/scrape-openapi-retry-delay: "5s"
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
     gloo.solo.io/scrape-openapi-pull-attempts: "3"
     gloo.solo.io/scrape-openapi-use-backoff: "true"
   name: pets-rest-api-v1

--- a/gloo-gateway/portal/pets-api-v2.yaml
+++ b/gloo-gateway/portal/pets-api-v2.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     gloo.solo.io/scrape-openapi-source: /swagger.json
-    gloo.solo.io/scrape-openapi-retry-delay: "5s"
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
     gloo.solo.io/scrape-openapi-pull-attempts: "3"
     gloo.solo.io/scrape-openapi-use-backoff: "true"
   name: pets-rest-api-v2

--- a/gloo-gateway/portal/pets-api.yaml
+++ b/gloo-gateway/portal/pets-api.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     gloo.solo.io/scrape-openapi-source: /swagger.json
-    gloo.solo.io/scrape-openapi-retry-delay: "5s"
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
     gloo.solo.io/scrape-openapi-pull-attempts: "3"
     gloo.solo.io/scrape-openapi-use-backoff: "true"
   name: pets-rest-api

--- a/gloo-gateway/portal/store-api.yaml
+++ b/gloo-gateway/portal/store-api.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     gloo.solo.io/scrape-openapi-source: /swagger.json
-    gloo.solo.io/scrape-openapi-retry-delay: "5s"
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
     gloo.solo.io/scrape-openapi-pull-attempts: "3"
     gloo.solo.io/scrape-openapi-use-backoff: "true"
   name: store-rest-api

--- a/gloo-gateway/portal/users-api.yaml
+++ b/gloo-gateway/portal/users-api.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   annotations:
     gloo.solo.io/scrape-openapi-source: /swagger.json
-    gloo.solo.io/scrape-openapi-retry-delay: "5s"
+    gloo.solo.io/scrape-openapi-retry-delay: "30s"
     gloo.solo.io/scrape-openapi-pull-attempts: "3"
     gloo.solo.io/scrape-openapi-use-backoff: "true"
   name: users-rest-api


### PR DESCRIPTION
The `ApiDoc` is not getting generated with `gloo.solo.io/scrape-openapi-retry-delay: "5s"`. 
The [tracks SVC](https://raw.githubusercontent.com/solo-io/gloo-mesh-use-cases/main/gloo-gateway/portal/tracks-api.yaml) already has 30s configured.
Changing the rest of the SVCs referred [here in our docs](https://docs.solo.io/gloo-gateway/latest/portal/apis/apidocs/#deploy) since overwriting the annotation is also not helping in generation of `ApiDoc` in my cluster e.g. `kubectl -n users annotate service users-rest-api --overwrite gloo.solo.io/scrape-openapi-retry-delay="30s"`
