### PR TITLE
Drop obsolete env var for `sni-dnat`

### DIFF
--- a/gloo-gateway/istio-install/eastwest-gateway.yaml
+++ b/gloo-gateway/istio-install/eastwest-gateway.yaml
@@ -51,12 +51,6 @@ spec:
             requests:
               cpu: 100m
               memory: 40Mi
-          env:
-            # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-            # The default value ('standard') does not set up a passthrough cluster.
-            # Required for multi-cluster communication and to preserve SNI.
-            - name: ISTIO_META_ROUTER_MODE
-              value: "sni-dnat"
           service:
             # Required to onboard VMs
             #type: LoadBalancer

--- a/gloo-gateway/istio-install/manual-helm/eastwest-gateway.yaml
+++ b/gloo-gateway/istio-install/manual-helm/eastwest-gateway.yaml
@@ -42,11 +42,7 @@ service:
       #targetPort: 15012
       # Required for VM onboarding discovery address
       #name: tls-istiod
-env:
-  # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-  # The default value ('standard') does not set up a passthrough cluster.
-  # Required for multi-cluster communication and to preserve SNI.
-  ISTIO_META_ROUTER_MODE: "sni-dnat"
+      #name: tls-istiod
 
 # Gateway pod resources
 resources:

--- a/gloo-mesh/istio-install/gm-managed/gm-egress-gateway.yaml
+++ b/gloo-mesh/istio-install/gm-managed/gm-egress-gateway.yaml
@@ -56,12 +56,6 @@ spec:
                                values:
                                  - arm64
                                  - amd64
-                env:
-                  # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-                  # The default value ('standard') does not set up a passthrough cluster.
-                  # Required for multi-cluster communication and to preserve SNI.
-                  - name: ISTIO_META_ROUTER_MODE
-                    value: "sni-dnat"
                 podAnnotations:
                   proxy.istio.io/config: |
                     proxyStatsMatcher:

--- a/gloo-mesh/istio-install/gm-managed/gm-ew-gateway.yaml
+++ b/gloo-mesh/istio-install/gm-managed/gm-ew-gateway.yaml
@@ -35,12 +35,6 @@ spec:
             istio: eastwestgateway
             app: istio-eastwestgateway
           k8s:
-            env:
-              # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-              # The default value ('standard') does not set up a passthrough cluster.
-              # Required for multi-cluster communication and to preserve SNI.
-              - name: ISTIO_META_ROUTER_MODE
-                value: "sni-dnat"
             service:
               type: LoadBalancer
               selector:

--- a/gloo-mesh/istio-install/manual-helm/eastwest-gateway.yaml
+++ b/gloo-mesh/istio-install/manual-helm/eastwest-gateway.yaml
@@ -42,11 +42,6 @@ service:
       #targetPort: 15012
       # Required for VM onboarding discovery address
       #name: tls-istiod
-env:
-  # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-  # The default value ('standard') does not set up a passthrough cluster.
-  # Required for multi-cluster communication and to preserve SNI.
-  ISTIO_META_ROUTER_MODE: "sni-dnat"
 
 # Gateway pod resources
 resources:

--- a/gloo-mesh/istio-install/vm-agent/aws.yaml
+++ b/gloo-mesh/istio-install/vm-agent/aws.yaml
@@ -52,12 +52,6 @@ spec:
             requests:
               cpu: 100m
               memory: 40Mi
-          env:
-            # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-            # The default value ('standard') does not set up a passthrough cluster.
-            # Required for multi-cluster communication and to preserve SNI.
-            - name: ISTIO_META_ROUTER_MODE
-              value: "sni-dnat"
           service:
             # Required to onboard VMs
             type: LoadBalancer

--- a/gloo-mesh/istio-install/vm-agent/azure.yaml
+++ b/gloo-mesh/istio-install/vm-agent/azure.yaml
@@ -49,12 +49,6 @@ spec:
             requests:
               cpu: 100m
               memory: 40Mi
-          env:
-            # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-            # The default value ('standard') does not set up a passthrough cluster.
-            # Required for multi-cluster communication and to preserve SNI.
-            - name: ISTIO_META_ROUTER_MODE
-              value: "sni-dnat"
           service:
             type: LoadBalancer
             # Required to onboard VMs

--- a/gloo-mesh/istio-install/vm-agent/gcp.yaml
+++ b/gloo-mesh/istio-install/vm-agent/gcp.yaml
@@ -49,12 +49,6 @@ spec:
             requests:
               cpu: 100m
               memory: 40Mi
-          env:
-            # 'sni-dnat' enables AUTO_PASSTHROUGH mode for east-west communication through the gateway.
-            # The default value ('standard') does not set up a passthrough cluster.
-            # Required for multi-cluster communication and to preserve SNI.
-            - name: ISTIO_META_ROUTER_MODE
-              value: "sni-dnat"
           service:
             # Required to onboard VMs
             type: LoadBalancer


### PR DESCRIPTION
This var was removed 3.5 years ago in Istio and does nothing now.