### PR TITLE
Typo in eastwest gw yaml

### DIFF
--- a/gloo-mesh/istio-install/manual-helm/eastwest-gateway-1.24+.yaml
+++ b/gloo-mesh/istio-install/manual-helm/eastwest-gateway-1.24+.yaml
@@ -42,7 +42,7 @@ service:
     # Port required for VM onboarding
     - port: 15012
       targetPort: 15012
-       Required for VM onboarding discovery address
+      # Required for VM onboarding discovery address
       name: tls-istiod
 
 # Gateway pod resources


### PR DESCRIPTION
otherwise it errors:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
gateway:
- service.ports.2.targetPort: Invalid type. Expected: integer, given: string
```