### PR TITLE
Update keycloak.yaml

### DIFF
--- a/policy-demo/oidc/keycloak.yaml
+++ b/policy-demo/oidc/keycloak.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: keycloak
-        image: quay.io/keycloak/keycloak:25.0.1
+        image: quay.io/keycloak/keycloak:26.1.3
         args: ["start-dev"]
         env:
         - name: KEYCLOAK_ADMIN
@@ -42,6 +42,8 @@ spec:
           value: "admin"
         - name: PROXY_ADDRESS_FORWARDING
           value: "true"
+        - name: KC_PROXY
+          value: "edge"
         ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
Keycloak 25  will not allow you to login with the default install ( invalid cookie ) ,  upgrading to 26.1.3  and adding a edge proxy fixes this issue.